### PR TITLE
feat: add a build helper: Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Create ubuntu as base image
+FROM ubuntu:16.04
+
+# Install packages
+ENV CXX g++
+ENV CC gcc
+ENV DEBIAN_FRONTEND noninteractive
+RUN cp /etc/apt/sources.list /etc/apt/sources.list~
+RUN sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
+RUN apt-get -y update
+RUN apt-get -yq install libc-ares-dev libicu-dev libctemplate-dev libtidy-dev uuid-dev libxml2-dev libsasl2-dev liblzma-dev libxml2-dev
+RUN apt-get -yq install wget sudo cmake autoconf automake libtool-bin gcc-5 g++-5 libglib2.0-dev
+
+# Copy Source code
+WORKDIR /app
+COPY . .
+
+# Add user ubuntu and allow sudo
+RUN adduser --disabled-password --gecos "" ubuntu
+RUN usermod -g sudo ubuntu
+RUN passwd -d ubuntu
+RUN chown -R ubuntu:ubuntu /app
+USER ubuntu

--- a/README.md
+++ b/README.md
@@ -160,3 +160,22 @@ The application does not seem to like being debugged in `Debug` mode. You need
 to use the `Release` configuration. This seems to be because there's a "Debug
 Heap" that is enabled in Debug configurations, and memory allocated by libetpan
 and de-allocated in mailcore2 isn't reference tracked properly.
+
+
+## Build with Docker (linux)
+
+To start docker env
+```bash
+docker build -t mailsync:1.0 .
+docker run -it mailsync:1.0
+```
+
+To start build
+```bash
+./build.sh
+```
+
+To use so lib in Mailspring repo
+```bash
+sh move_so_lib.sh
+```

--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ elif [[ "$OSTYPE" == "linux-gnu" ]]; then
     # is too old. We need v7.46 or greater.
     echo "Building and installing curl-7.70.0..."
     cd "$DEP_BUILDS_DIR"
-    sudo apt-get build-dep curl
+    sudo apt-get -y build-dep curl
     wget -q http://curl.haxx.se/download/curl-7.70.0.tar.bz2
     tar -xjf curl-7.70.0.tar.bz2
     cd curl-7.70.0


### PR DESCRIPTION
Since there are lots of obsoleted package in linux build, docker could easily keep the build possible.