### PR TITLE
 SMTP fix - Community#1625

### DIFF
--- a/Vendor/mailcore2/src/core/smtp/MCSMTPSession.cpp
+++ b/Vendor/mailcore2/src/core/smtp/MCSMTPSession.cpp
@@ -699,7 +699,7 @@ void SMTPSession::checkAccount(Address * from, ErrorCode * pError)
         return;
     }
     
-    r = mailsmtp_rcpt(mSmtp, "email@invalid.com");
+    r = mailsmtp_rcpt(mSmtp, MCUTF8(from->mailbox()));
     saveLastResponse();
     if (r == MAILSMTP_ERROR_STREAM) {
         * pError = ErrorConnection;

--- a/Vendor/mailcore2/src/core/smtp/MCSMTPSession.cpp
+++ b/Vendor/mailcore2/src/core/smtp/MCSMTPSession.cpp
@@ -717,16 +717,17 @@ void SMTPSession::checkAccount(Address * from, ErrorCode * pError)
     builder.header()->setUserAgent(MCSTR("Mailspring"));
     builder.header()->setDate(time(0));
 
+    Address* me = Address::addressWithMailbox(from->mailbox());
+
     Array* to = new Array();
-    to->addObject(Address::addressWithDisplayName(MCSTR("Mailspring Team"), from->mailbox()));
+    to->addObject(me);
     builder.header()->setTo(to);
 
     Array* replyTo = new Array();
-    Address* me = Address::addressWithMailbox(from->mailbox());
     replyTo->addObject(me);
 
     builder.header()->setReplyTo(replyTo);
-    builder.header()->setFrom(me);
+    builder.header()->setFrom(Address::addressWithDisplayName(MCSTR("Mailspring Team"), from->mailbox()));
     builder.setTextBody(MCSTR(
         "This is an email sent by Mailspring while we were testing your account config.\r\n\r\n"
         "As you've received it, everything must be a-ok.\r\n\r\n"

--- a/Vendor/mailcore2/src/core/smtp/MCSMTPSession.cpp
+++ b/Vendor/mailcore2/src/core/smtp/MCSMTPSession.cpp
@@ -699,7 +699,7 @@ void SMTPSession::checkAccount(Address * from, ErrorCode * pError)
         return;
     }
     
-    r = mailsmtp_rcpt(mSmtp, MCUTF8(from->mailbox()));
+    r = mailsmtp_rcpt(mSmtp, "email@invalid.com");
     saveLastResponse();
     if (r == MAILSMTP_ERROR_STREAM) {
         * pError = ErrorConnection;


### PR DESCRIPTION
Though this will fix [Comunity#1625](https://community.getmailspring.com/t/account-set-up-fails-with-smtp-error/1625), I believe it is a partial fix.

Ideally, I would like a nice subject plus a body like "This is a test email sent whilst Mailspring was setting up your account". However, my C++ knowledge is nonexistent, so I can not do this myself.

---
<details><summary>Compilation issue</summary>
I tried to run the build (that I finally managed to compile) but it failed with the error shown (all missing dll's detailed below)

![image](https://user-images.githubusercontent.com/33450392/194900044-6f91d72c-4871-4ee5-8529-280a430f8d4f.png)

Not sure where to find the code I need to compile the missing DLL's (as I said, I have no C++ experience 😂)
- libxml2.dll
- libcryptoMD.dll
- libtidy.dll

</details>