### PR TITLE
Draft: Mailsync support for US GCC environments in Office 365.

### DIFF
--- a/MailSync/NetworkRequestUtils.cpp
+++ b/MailSync/NetworkRequestUtils.cpp
@@ -64,6 +64,7 @@ const json MakeOAuthRefreshRequest(string provider, string clientId, string refr
     const char * url =
           provider == "gmail" ? "https://www.googleapis.com/oauth2/v4/token"
         : provider == "office365" ? "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+        : provider == "office365us" ? "https://login.microsoftonline.us/common/oauth2/v2.0/token"
         : "";
     curl_easy_setopt(curl_handle, CURLOPT_URL, url);
     curl_easy_setopt(curl_handle, CURLOPT_CONNECTTIMEOUT, 20);
@@ -76,6 +77,10 @@ const json MakeOAuthRefreshRequest(string provider, string clientId, string refr
         // have to get a separate token for outlook (email + IMAP) and contacts / calendar / Microsoft Graph APIs
         // separately. The same refresh token will give you access tokens, but the access tokens are different.
         payload += "&scope=https%3A%2F%2Foutlook.office365.com%2FIMAP.AccessAsUser.All%20https%3A%2F%2Foutlook.office365.com%2FSMTP.Send";
+    }
+    else if (provider == "office365us") {
+        // gcc cloud works similarly to above.
+        payload += "&scope=https%3A%2F%2Foutlook.office365.us%2FIMAP.AccessAsUser.All%20https%3A%2F%2Foutlook.office365.us%2FSMTP.Send";
     }
 
     string gmailClientId = MailUtils::getEnvUTF8("GMAIL_CLIENT_ID");

--- a/Vendor/mailcore2/resources/providers.json
+++ b/Vendor/mailcore2/resources/providers.json
@@ -1333,6 +1333,30 @@
             "trash": "Deleted Items"
         }
     },
+    "office365us": {
+        "servers": {
+            "imap": [
+                {
+                    "port": 993,
+                    "hostname": "outlook.office365.us",
+                    "ssl": true
+                }
+            ],
+            "smtp": [
+                {
+                    "port": 587,
+                    "hostname": "smtp.office365.us",
+                    "starttls": true
+                }
+            ]
+        },
+        "mailboxes": {
+            "drafts": "Drafts",
+            "spam": "Junk Email",
+            "sentmail": "Sent Items",
+            "trash": "Deleted Items"
+        }
+    },
     "wp.pl": {
         "servers": {
             "imap": [


### PR DESCRIPTION
There are other GCC/secure clouds besides .us for Office 365, a better solution than attached to this pull request might be to add the token refresh url to the providers.json for oauth2 providers and "additional payload parameters" (though, you'll still need that special if statement for gmail). 