### PR TITLE
fix(MailSync/GoogleContactsWorker.cpp): enable contact sync to gracefully handle when a contact has a name but not a display name

### DIFF
--- a/MailSync/GoogleContactsWorker.cpp
+++ b/MailSync/GoogleContactsWorker.cpp
@@ -275,7 +275,6 @@ void GoogleContactsWorker::upsertContact(shared_ptr<Contact> contact) {
 }
 
 void GoogleContactsWorker::applyJSONToContact(shared_ptr<Contact> local, const json & conn) {
-    logger->debug("Applying JSON to Contact: {}", conn.dump());
     auto primaryName = conn.count("names") ? conn["names"][0].value("displayName", "").get<string>() : "";
     auto primaryEmail = conn.count("emailAddresses") ? conn["emailAddresses"][0].value("value", "").get<string>() : "";
     local->setEmail(primaryEmail);

--- a/MailSync/GoogleContactsWorker.cpp
+++ b/MailSync/GoogleContactsWorker.cpp
@@ -275,8 +275,9 @@ void GoogleContactsWorker::upsertContact(shared_ptr<Contact> contact) {
 }
 
 void GoogleContactsWorker::applyJSONToContact(shared_ptr<Contact> local, const json & conn) {
-    auto primaryName = conn.count("names") ? conn["names"][0]["displayName"].get<string>() : "";
-    auto primaryEmail = conn.count("emailAddresses") ? conn["emailAddresses"][0]["value"].get<string>() : "";
+    logger->debug("Applying JSON to Contact: {}", conn.dump());
+    auto primaryName = conn.count("names") ? conn["names"][0].value("displayName", "").get<string>() : "";
+    auto primaryEmail = conn.count("emailAddresses") ? conn["emailAddresses"][0].value("value", "").get<string>() : "";
     local->setEmail(primaryEmail);
     local->setName(primaryName);
     local->setInfo(conn);


### PR DESCRIPTION
Intended to fix this SIGABRT but not tested or validated in any way
```
35216 [2023-03-28 11:36:59.174] [calContacts] [critical] 
***
*** Mailspring Sync 
*** An abort error (SIGABRT) occurred during program execution: 
*** system functions that detect corrupt state.
***

35216 [2023-03-28 11:36:59.184] [foreground] [info] [local-c0692241-131b] -- Succeeded. Changing status to `complete`
35216 [2023-03-28 11:36:59.198] [background] [info] Sync loop deleting unlinked messages with phase 2.
35216 [2023-03-28 11:36:59.198] [background] [info] Sync loop complete.
35216 [2023-03-28 11:36:59.198] [background] [info] Syncing folder list...
35216 [2023-03-28 11:36:59.251] [foreground] [info] syncFolderChangesViaCondstore - [Gmail]/All Mail: modseq 11009542 to 11009591, uidnext 179595 to 179595
35216 [2023-03-28 11:36:59.285] [calContacts] [critical] *** Stack trace (line numbers are approximate):
*** 0x185c21cec  pthread_kill()
*** 0x185b5a2c8  abort()
*** 0x185b59620  err()
*** in mailsync  nlohmann::basic_json const& nlohmann::basic_json::operator[](char const*) const
*** in mailsync  GoogleContactsWorker::applyJSONToContact(shared_ptr, nlohmann::basic_json const&)
*** in mailsync  GoogleContactsWorker::run()::$_0::operator()(nlohmann::basic_json) const
*** in mailsync  decltype(static_cast(fp)(static_cast(fp0))) __invoke(GoogleContactsWorker::run()::$_0&, nlohmann::basic_json&&)
*** in mailsync  GoogleContactsWorker::paginateGoogleCollection(string, string, string, function)
*** in mailsync  GoogleContactsWorker::run()
*** in mailsync  runCalContactsSyncWorker()
*** in mailsync  main::$_7::operator()() const
*** in mailsync  void* __thread_proxy(void*)
*** 0x185c1ce2c  thread_start()
```