### PR TITLE
Windows: upgrade from Visual Studio 2015 to 2022

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,24 +1,37 @@
 version: '{build}'
 
-branches:
-  only:
-    - master
-    - /ci.*/
-    - /stable.*/
+skip_branch_with_pr: true
 
-skip_non_tags: true
-
-image: Visual Studio 2017
+image: Visual Studio 2022
 
 init:
   - ps: $env:commit = $env:appveyor_repo_commit.SubString(0,8)
 
-install:
-  - ps: npm config set msvs_version 2017
-
 build_script:
   - ps: mkdir ..\app
-  - cmd: .\build.cmd
+  - cmd: cd Windows && msbuild.exe mailsync.sln /property:Configuration=Release;Platform=Win32
+  - cmd: |
+      IF not exist ..\..\app\dist (mkdir ..\..\app\dist)
+      XCOPY .\Release\*.* ..\..\app\dist
+      COPY "C:\Windows\SysWOW64\msvcr100.dll" ..\..\app\dist\ /Y
+      COPY "C:\Windows\SysWOW64\msvcr120.dll" ..\..\app\dist\ /Y
+      COPY "C:\Windows\SysWOW64\msvcp100.dll" ..\..\app\dist\ /Y
+      COPY "C:\Windows\SysWOW64\msvcp120.dll" ..\..\app\dist\ /Y
+      COPY "C:\Windows\SysWOW64\msvcp140.dll" ..\..\app\dist\ /Y
+      COPY "C:\Windows\SysWOW64\vcruntime140.dll" ..\..\app\dist\ /Y
+      XCOPY /rhy "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\x86" ..\..\app\dist\
+  # Validate that the program exits with code 2 (missing arguments). If any DLLs are missing that
+  # prevent the application from starting, a code like -1073741515 will be returned.
+  - ps: |
+      $process = Start-Process -FilePath "..\..\app\dist\mailsync.exe" -PassThru -Wait -NoNewWindow
+      $exitCode = $process.ExitCode
+
+      if ($exitCode -ne 2) {
+        Write-Host "We expected mailsync.exe to exit with code 2, but we got $exitCode instead."
+        exit 1
+      } else {
+        Write-Host "Exit code was as expected: $exitCode"
+      }
 
 before_deploy:
   - ps: (Get-ChildItem -Force -Path ..\..\app).FullName
@@ -36,6 +49,9 @@ deploy:
     bucket: mailspring-builds
     folder: 'mailsync/$(commit)'
     set_public: true
+    # Deploy only when a new tag is created
+    on:
+      APPVEYOR_REPO_TAG: true
 
 # Stop Appveyor from "Discovering Tests" forever
 test: off

--- a/Vendor/libetpan/build-windows/libetpan/libetpan.vcxproj
+++ b/Vendor/libetpan/build-windows/libetpan/libetpan.vcxproj
@@ -22,27 +22,27 @@
     <ProjectGuid>{BA4DED3C-E56F-4484-BFC3-9C13E461A1BE}</ProjectGuid>
     <RootNamespace>libetpan</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Vendor/mailcore2/build-windows/mailcore2/mailcore2/mailcore2.vcxproj
+++ b/Vendor/mailcore2/build-windows/mailcore2/mailcore2/mailcore2.vcxproj
@@ -345,32 +345,32 @@ build_headers.bat
     <ProjectGuid>{AAD35E01-77E4-43CB-BBB4-F7F6692EA829}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>mailcore2</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -408,7 +408,7 @@ build_headers.bat
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>MAILCORE_DLL;ZLIB_DLL;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MAILCORE_DLL;ZLIB_DLL;_WINDLL;HAVE_STRUCT_TIMESPEC;_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory);..\..\include;..\..\..\Externals\include;..\..\..\src\core\basetypes;..\..\..\src\core\zip;..\..\..\src\core\zip\minizip;..\..\..\src\core\renderer;..\..\..\src\core/rfc822;..\..\..\src\core/imap;..\..\..\src\core\abstract;..\..\..\src\core\security;..\..\..\src\core\nntp;..\..\..\src\core\smtp;..\..\..\src\core\pop;</AdditionalIncludeDirectories>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
@@ -426,7 +426,7 @@ build_headers.bat
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>MAILCORE_DLL;ZLIB_DLL;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MAILCORE_DLL;ZLIB_DLL;_WINDLL;HAVE_STRUCT_TIMESPEC;_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory);..\..\include;..\..\..\Externals\include;..\..\..\src\core\basetypes;..\..\..\src\core\zip;..\..\..\src\core\zip\minizip;..\..\..\src\core\renderer;..\..\..\src\core/rfc822;..\..\..\src\core/imap;..\..\..\src\core\abstract;..\..\..\src\core\security;..\..\..\src\core\imap;..\..\..\src\core\pop;..\..\..\src\core\nntp;..\..\..\src\core\smtp</AdditionalIncludeDirectories>
     </ClCompile>

--- a/Vendor/mailcore2/build-windows/mailcore2/mailcore2/mailcore2.vcxproj
+++ b/Vendor/mailcore2/build-windows/mailcore2/mailcore2/mailcore2.vcxproj
@@ -444,7 +444,7 @@ build_headers.bat
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>MAILCORE_DLL;ZLIB_DLL;_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MAILCORE_DLL;ZLIB_DLL;_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS;_WINDLL;HAVE_STRUCT_TIMESPEC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory);..\..\include;..\..\..\Externals\include;..\..\..\src\core\basetypes;..\..\..\src\core\zip;..\..\..\src\core\zip\minizip;..\..\..\src\core\renderer;..\..\..\src\core/rfc822;..\..\..\src\core/imap;..\..\..\src\core\abstract;..\..\..\src\core\security;..\..\..\src\core\imap;..\..\..\src\core\pop;..\..\..\src\core\nntp;..\..\..\src\core\smtp</AdditionalIncludeDirectories>
     </ClCompile>
@@ -464,7 +464,7 @@ build_headers.bat
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>MAILCORE_DLL;ZLIB_DLL;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MAILCORE_DLL;ZLIB_DLL;_WINDLL;HAVE_STRUCT_TIMESPEC;_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory);..\..\include;..\..\..\Externals\include;..\..\..\src\core\basetypes;..\..\..\src\core\zip;..\..\..\src\core\zip\minizip;..\..\..\src\core\renderer;..\..\..\src\core/rfc822;..\..\..\src\core/imap;..\..\..\src\core\abstract;..\..\..\src\core\security;..\..\..\src\core\imap;..\..\..\src\core\pop;..\..\..\src\core\nntp;..\..\..\src\core\smtp</AdditionalIncludeDirectories>
     </ClCompile>

--- a/Windows/mailsync.vcxproj
+++ b/Windows/mailsync.vcxproj
@@ -85,7 +85,21 @@ _TIMESPEC_DEFINED;SQLITE_ENABLE_FTS5;CURL_STATICLIB;SPDLOG_WCHAR_FILENAMES;%(Pre
       <AdditionalDependencies>legacy_stdio_definitions.lib;libcurl_a.lib;libxml2.lib;zlib.lib;iconv_a.lib;dbghelp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Ws2_32.lib;Dnsapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>IF not exist ..\..\app\dist (mkdir ..\..\app\dist) &amp;&amp; COPY .\Release\mailsync.exe ..\..\app\dist\ /Y &amp;&amp; COPY .\Release\mailsync.pdb ..\..\app\dist\ /Y &amp;&amp; COPY .\Release\libetpan.dll ..\..\app\dist\ /Y &amp;&amp; COPY .\Release\mailcore2.dll ..\..\app\dist\ /Y &amp;&amp; COPY .\Release\mailcore2.pdb ..\..\app\dist\ /Y &amp;&amp; COPY ..\Vendor\libetpan\third-party\bin\libiconv2.dll ..\..\app\dist\ /Y &amp;&amp; COPY ..\Vendor\mailcore2\Externals\bin\icudt54.dll ..\..\app\dist\ /Y &amp;&amp; COPY ..\Vendor\mailcore2\Externals\bin\icuin54.dll ..\..\app\dist\ /Y &amp;&amp; COPY ..\Vendor\mailcore2\Externals\bin\icuuc54.dll ..\..\app\dist\ /Y &amp;&amp; COPY ..\Vendor\mailcore2\Externals\lib\libctemplate.dll ..\..\app\dist\ /Y &amp;&amp; COPY ..\Vendor\mailcore2\Externals\bin\libcryptoMD.dll ..\..\app\dist\ /Y &amp;&amp; COPY ..\Vendor\mailcore2\Externals\lib\sasl2.dll ..\..\app\dist\ /Y &amp;&amp; COPY ..\Vendor\mailcore2\Externals\lib\libtidy.dll ..\..\app\dist\ /Y &amp;&amp; COPY ..\Vendor\mailcore2\Externals\lib\libxml2.dll ..\..\app\dist\ /Y &amp;&amp; COPY ..\Vendor\mailcore2\Externals\dll\x86\pthreadVC2.dll ..\..\app\dist\ /Y &amp;&amp; COPY ..\Vendor\mailcore2\Externals\bin\libsslMD.dll ..\..\app\dist\ /Y &amp;&amp; COPY ..\Vendor\mailcore2\Externals\lib\zlib.dll ..\..\app\dist\ /Y &amp;&amp; COPY "C:\Windows\SysWOW64\msvcr100.dll" ..\..\app\dist\ /Y &amp;&amp; COPY "C:\Windows\SysWOW64\msvcr120.dll" ..\..\app\dist\ /Y &amp;&amp; COPY "C:\Windows\SysWOW64\msvcp100.dll" ..\..\app\dist\ /Y &amp;&amp; COPY "C:\Windows\SysWOW64\msvcp120.dll" ..\..\app\dist\ /Y &amp;&amp; COPY "C:\Windows\SysWOW64\msvcp140.dll" ..\..\app\dist\ /Y &amp;&amp; COPY "C:\Windows\SysWOW64\vcruntime140.dll" ..\..\app\dist\ /Y &amp;&amp; XCOPY /rhy "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\x86" ..\..\app\dist\ &amp;&amp; CD ..\..\app\dist &amp;&amp; XCOPY *.* ..\</Command>
+      <Message>Copying project dependencies into the $(TargetDir) folder...</Message>
+      <Command>
+        COPY $(ProjectDir)..\Vendor\libetpan\third-party\bin\libiconv2.dll $(TargetDir) /Y
+        COPY $(ProjectDir)..\Vendor\mailcore2\Externals\bin\icudt54.dll $(TargetDir) /Y
+        COPY $(ProjectDir)..\Vendor\mailcore2\Externals\bin\icuin54.dll $(TargetDir) /Y
+        COPY $(ProjectDir)..\Vendor\mailcore2\Externals\bin\icuuc54.dll $(TargetDir) /Y
+        COPY $(ProjectDir)..\Vendor\mailcore2\Externals\lib\libctemplate.dll $(TargetDir) /Y
+        COPY $(ProjectDir)..\Vendor\mailcore2\Externals\bin\libcryptoMD.dll $(TargetDir) /Y
+        COPY $(ProjectDir)..\Vendor\mailcore2\Externals\lib\sasl2.dll $(TargetDir) /Y
+        COPY $(ProjectDir)..\Vendor\mailcore2\Externals\lib\libtidy.dll $(TargetDir) /Y
+        COPY $(ProjectDir)..\Vendor\mailcore2\Externals\lib\libxml2.dll $(TargetDir) /Y
+        COPY $(ProjectDir)..\Vendor\mailcore2\Externals\dll\x86\pthreadVC2.dll $(TargetDir) /Y
+        COPY $(ProjectDir)..\Vendor\mailcore2\Externals\bin\libsslMD.dll $(TargetDir) /Y
+        COPY $(ProjectDir)..\Vendor\mailcore2\Externals\lib\zlib.dll $(TargetDir) /Y
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Windows/mailsync.vcxproj
+++ b/Windows/mailsync.vcxproj
@@ -14,19 +14,19 @@
     <ProjectGuid>{FD5B276A-CB56-4697-8C6F-C02FF68AB435}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>mailsync</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,0 @@
-"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat" && ^
-cd Windows && ^
-msbuild.exe mailsync.sln /property:Configuration=Release


### PR DESCRIPTION
This PR upgrades the build logic so it can build on Visual Studio 2022 as well.

## VS-specific fixes

Upgrading to VS 2022 was relatively easy. In 3b5fdb8a7965ee2ba07389f9a606d32ea2e9a3d1, you can see that I could upload the `PlatformToolset` to `v143` and only had to ensure `HAVE_STRUCT_TIMESPEC` and `_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS` were set during build time. This should also fix the Debug builds.

In a7f1f1243c5468a6bf83db730a60183d9575b530, I took the opportunity to update `mailsync.vcxproj` a bit to make it easier to follow. Instead of writing into `..\..\app\dist` directly, I'm now writing to `$(TargetDir)` instead, so that all the requirements end up in the same folder.

I thought it make sense to split up the dependencies into direct ones (e.g. [`libiconv2.dll`](https://github.com/Foundry376/Mailspring-Sync/commit/a7f1f1243c5468a6bf83db730a60183d9575b530#diff-15e9884c9a9cd4dcd27b8a9c186f5f705a1d7d2f364deb909d9f2a4c72b2ef7bR90)) and platform-related ones (e.g. [`msvcr120.dll`](https://github.com/Foundry376/Mailspring-Sync/commit/a7f1f1243c5468a6bf83db730a60183d9575b530#diff-e1ab4c3cec24f841948eb867754d4ad0b9b6d11eaa6b5bfbe0357aceb0a49effR17)), of which the latter are added by AppVeyor, because not all machines have those old redistributable VC versions (2010 and 2013) installed. But happy to add them all back to the `mailsync.vcxproj` if you prefer.

## AppVeyor changes

I think it'd be nice if AppVeyor runs on every PR, so that you can be sure that the build keeps working before merging to `master`. I added a condition to only deploy if `APPVEYOR_REPO_TAG` is set, meaning that it'll only deploy if you push a new tag to GitHub.

I also added a quick test to ensure `mailsync.exe` can actually start, which it won't if any of the `.dll` dependencies are missing. That should allow you to find out quickly if a breaking change is suggested by someone.

Moving forward, may I suggest to switch to GitHub Actions instead for these builds? They [support](https://github.com/actions/runner-images?tab=readme-ov-file#available-images) Ubuntu, Windows and macOS (all platforms you support) nowadays. Happy to create a follow-up PR to make the switch if you're up for that.

## Successful build

Here's a successful build from my fork: https://ci.appveyor.com/project/dennisameling/mailspring-sync/builds/50605099