### PR TITLE
Apply fix for IMAP 'UID FETCH' response parsing error - "eternal sync bug"

### DIFF
--- a/Vendor/libetpan/src/low-level/imap/mailimap_parser.h
+++ b/Vendor/libetpan/src/low-level/imap/mailimap_parser.h
@@ -183,12 +183,39 @@ int mailimap_capability_data_parse(mailstream * fd, MMAPString * buffer, struct 
 	size_t progr_rate,
 	progress_function * progr_fun);
 
+static int is_text_char(char ch);
+
 int mailimap_capability_list_parse(mailstream * fd,
   MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
   size_t * indx,
   clist ** result,
   size_t progr_rate,
   progress_function * progr_fun);
+
+int
+mailimap_any_char_except_parse ( mailstream* fd, MMAPString* buffer, struct mailimap_parser_context* parser_ctx,
+	size_t* indx, char* result, char except_char );
+
+static int
+mailimap_env_message_id_parse_icloud_workaround ( mailstream* fd,
+	MMAPString* buffer, struct mailimap_parser_context* parser_ctx,
+	size_t* indx, char** result,
+	size_t progr_rate,
+	progress_function* progr_fun );
+
+static int
+mailimap_env_message_id_parse ( mailstream* fd,
+	MMAPString* buffer, struct mailimap_parser_context* parser_ctx,
+	size_t* indx, char** result,
+	size_t progr_rate,
+	progress_function* progr_fun );
+
+static int
+mailimap_encapsulated_parse ( mailstream* fd, MMAPString* buffer, struct mailimap_parser_context* parser_ctx,
+	size_t* indx, char** result,
+	size_t progr_rate,
+	progress_function* progr_fun,
+	char open_token, char close_token, bool include_tokens );
 
 int mailimap_status_att_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
   size_t * indx, int * result);


### PR DESCRIPTION
### Summary
This PR applies a long-standing fix for a bug in the IMAP UID FETCH parser used by Mailspring.
The issue causes Mailspring to get stuck in an endless sync loop when processing certain IMAP server responses  - most notably from iCloud, but also some other providers. These responses appear to be technically illegal according to RFC, but are still used and break sync functionality.  Several users (including myself) are affected, which makes the application unusable because affected accounts can no longer fully sync.

The problem has been discussed for many years. It was first documented on Discourse in 2021, but related GitHub discussions go back as far as 2017:
[https://community.getmailspring.com/t/the-eternal-sync-bug/334](https://community.getmailspring.com/t/the-eternal-sync-bug/334)

### Background & History
The original analysis and fix was contributed by Sebtous (2023) here:
[https://github.com/dinhvh/libetpan/issues/426](https://github.com/dinhvh/libetpan/issues/426) and the Apple API issue described here  https://developer.apple.com/forums/thread/724704

Unfortunately, libetpan has been abandoned for years, so the fix was never merged upstream.

Recently a community member created a patcher to adapt the fix specifically for Mailspring:
[https://github.com/a-chaudhari/mailspring-patcher](https://github.com/a-chaudhari/mailspring-patcher) as described here: 
https://community.getmailspring.com/t/the-eternal-sync-bug/334/40

Because Mailspring vendors its own copy of libetpan, this PR brings the patch from a-chaudhari/mailspring-patcher directly into Mailspring-Sync so that the fix can move forward and potentially be integrated properly.

I attempted to build and verify the change myself, but due to several outdated components and the fact that I am not a C developer, I could not fully complete the build locally. I’m contributing this so others can continue the work.

### What This PR Does
This PR updates only two files in the vendored IMAP parser:

- mailimap_parser.c
- mailimap_parser.h

It integrates the community patch so that the UID FETCH parsing issue may be resolved in future Mailspring builds.