### PR TITLE
Cherry-pick upstream mailcore2 bug fixes and improvements

### DIFF
--- a/Vendor/libetpan/src/data-types/mailstream_ssl.c
+++ b/Vendor/libetpan/src/data-types/mailstream_ssl.c
@@ -624,7 +624,7 @@ static struct mailstream_ssl_data * ssl_data_new(int fd, time_t timeout,
 		timeout_value = mailstream_network_delay.tv_sec * 1000 + mailstream_network_delay.tv_usec / 1000;
   }
   else {
-		timeout_value = timeout;
+		timeout_value = timeout * 1000;
   }
 #if GNUTLS_VERSION_NUMBER >= 0x030100
 	gnutls_handshake_set_timeout(session, timeout_value);

--- a/Vendor/libetpan/src/low-level/imap/mailimap.c
+++ b/Vendor/libetpan/src/low-level/imap/mailimap.c
@@ -749,7 +749,13 @@ int mailimap_logout(mailimap * session)
   }
 
   r = mailimap_parse_response(session, &response);
-  if (r != MAILIMAP_NO_ERROR) {
+  if (r == MAILIMAP_ERROR_STREAM) {
+    // the response is expected to be MAILIMAP_ERROR_STREAM
+    // because the server responds with BYE so the stream
+    // is immediately closed
+    res = MAILIMAP_NO_ERROR;
+    goto close;
+  } else if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto close;
   }
@@ -2421,6 +2427,13 @@ int mailimap_starttls(mailimap * session)
   error_code = response->rsp_resp_done->rsp_data.rsp_tagged->rsp_cond_state->rsp_type;
 
   mailimap_response_free(response);
+
+  // Detect if the server send extra data after the STARTTLS response.
+  // This *may* be a "response injection attack".
+  if (session->imap_stream->read_buffer_len != 0) {
+      // Since it is also an IMAP protocol violation, exit.
+      return MAILIMAP_ERROR_STARTTLS;
+  }
 
   switch (error_code) {
   case MAILIMAP_RESP_COND_STATE_OK:

--- a/Vendor/libetpan/src/low-level/imap/mailimap_types.c
+++ b/Vendor/libetpan/src/low-level/imap/mailimap_types.c
@@ -1389,9 +1389,11 @@ void
 mailimap_mailbox_data_status_free(struct mailimap_mailbox_data_status * info)
 {
   mailimap_mailbox_free(info->st_mailbox);
-  clist_foreach(info->st_info_list, (clist_func) mailimap_status_info_free,
-		 NULL);
-  clist_free(info->st_info_list);
+  if (info->st_info_list != NULL) {
+    clist_foreach(info->st_info_list, (clist_func) mailimap_status_info_free,
+      NULL);
+    clist_free(info->st_info_list);
+  }
   free(info);
 }
 

--- a/Vendor/libetpan/src/low-level/imap/quota_parser.c
+++ b/Vendor/libetpan/src/low-level/imap/quota_parser.c
@@ -103,7 +103,7 @@ mailimap_quota_quota_resource_parse(mailstream * fd, MMAPString * buffer, struct
 }
 
 static int
-mailimap_quota_quota_list_nonempty_parse(mailstream * fd, MMAPString * buffer,
+mailimap_quota_quota_list_nonempty_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx, clist ** result,
     size_t progr_rate, progress_function * progr_fun)
 {
@@ -114,13 +114,13 @@ mailimap_quota_quota_list_nonempty_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_oparenth_parse(fd, buffer, NULL, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer, NULL,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx,
       &cur_token, &quota_resource_list,
       &mailimap_quota_quota_resource_parse,
       (mailimap_struct_destructor *)
@@ -131,7 +131,7 @@ mailimap_quota_quota_list_nonempty_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, NULL, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto quota_list_free;
@@ -151,7 +151,7 @@ mailimap_quota_quota_list_nonempty_parse(mailstream * fd, MMAPString * buffer,
 }
 
 static int
-mailimap_quota_quota_list_empty_parse(mailstream * fd, MMAPString * buffer,
+mailimap_quota_quota_list_empty_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx, clist ** result,
     size_t progr_rate, progress_function * progr_fun)
 {
@@ -161,12 +161,12 @@ mailimap_quota_quota_list_empty_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_oparenth_parse(fd, buffer, NULL, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     return r;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, NULL, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     return r;
   }
@@ -183,24 +183,24 @@ mailimap_quota_quota_list_empty_parse(mailstream * fd, MMAPString * buffer,
 }
 
 static int
-mailimap_quota_quota_list_parse(mailstream * fd, MMAPString * buffer,
+mailimap_quota_quota_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx, clist ** result,
     size_t progr_rate, progress_function * progr_fun)
 {
   int r;
 
-  r = mailimap_quota_quota_list_empty_parse(fd, buffer, indx, result,
+  r = mailimap_quota_quota_list_empty_parse(fd, buffer, parser_ctx, indx, result,
       progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR) {
     return r;
   }
 
-  return mailimap_quota_quota_list_nonempty_parse(fd, buffer, indx, result,
+  return mailimap_quota_quota_list_nonempty_parse(fd, buffer, parser_ctx, indx, result,
       progr_rate, progr_fun);
 }
 
 static int
-mailimap_quota_quota_response_parse(mailstream * fd, MMAPString * buffer,
+mailimap_quota_quota_response_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx, struct mailimap_quota_quota_data ** result,
     size_t progr_rate, progress_function * progr_fun)
 {
@@ -226,7 +226,7 @@ mailimap_quota_quota_response_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_astring_parse(fd, buffer, NULL, &cur_token, &quotaroot,
+  r = mailimap_astring_parse(fd, buffer, parser_ctx, &cur_token, &quotaroot,
           progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -239,7 +239,7 @@ mailimap_quota_quota_response_parse(mailstream * fd, MMAPString * buffer,
     goto quotaroot_free;
   }
 
-  r = mailimap_quota_quota_list_parse(fd, buffer, &cur_token,
+  r = mailimap_quota_quota_list_parse(fd, buffer, parser_ctx, &cur_token,
       &quota_list, progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -268,7 +268,7 @@ mailimap_quota_quota_response_parse(mailstream * fd, MMAPString * buffer,
 }
 
 static int
-mailimap_quota_quotaroot_response_parse(mailstream * fd, MMAPString * buffer,
+mailimap_quota_quotaroot_response_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx, struct mailimap_quota_quotaroot_data ** result,
     size_t progr_rate, progress_function * progr_fun)
 {
@@ -295,7 +295,7 @@ mailimap_quota_quotaroot_response_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_mailbox_parse(fd, buffer, NULL, &cur_token, &mailbox,
+  r = mailimap_mailbox_parse(fd, buffer, parser_ctx, &cur_token, &mailbox,
           progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -317,7 +317,7 @@ mailimap_quota_quotaroot_response_parse(mailstream * fd, MMAPString * buffer,
       goto quotaroot_list_free;
     }
 
-    r = mailimap_astring_parse(fd, buffer, NULL, &cur_token, &quotaroot,
+    r = mailimap_astring_parse(fd, buffer, parser_ctx, &cur_token, &quotaroot,
         progr_rate, progr_fun);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
@@ -386,7 +386,7 @@ int mailimap_quota_parse(int calling_parser, mailstream * fd,
   switch (calling_parser)
   {
     case MAILIMAP_EXTENDED_PARSER_MAILBOX_DATA:
-      r = mailimap_quota_quota_response_parse(fd, buffer, indx,
+      r = mailimap_quota_quota_response_parse(fd, buffer, parser_ctx, indx,
         &quota_data, progr_rate, progr_fun);
       if (r == MAILIMAP_NO_ERROR) {
 	type = MAILIMAP_QUOTA_TYPE_QUOTA_DATA;
@@ -394,7 +394,7 @@ int mailimap_quota_parse(int calling_parser, mailstream * fd,
       }
 
       if (r == MAILIMAP_ERROR_PARSE) {
-	r = mailimap_quota_quotaroot_response_parse(fd, buffer, indx,
+	r = mailimap_quota_quotaroot_response_parse(fd, buffer, parser_ctx, indx,
           &quotaroot_data, progr_rate, progr_fun);
         if (r == MAILIMAP_NO_ERROR) {
           type = MAILIMAP_QUOTA_TYPE_QUOTAROOT_DATA;

--- a/Vendor/libetpan/src/low-level/mime/mailmime_write_generic.c
+++ b/Vendor/libetpan/src/low-level/mime/mailmime_write_generic.c
@@ -81,6 +81,9 @@ static int mailmime_version_write_driver(int (* do_write)(void *, const char *, 
 static int mailmime_encoding_write_driver(int (* do_write)(void *, const char *, size_t), void * data, int * col,
 				   struct mailmime_mechanism * encoding);
 
+static int mailmime_location_write_driver(int (* do_write)(void *, const char *, size_t), void *data, int *col,
+                                   char *location);
+
 static int mailmime_language_write_driver(int (* do_write)(void *, const char *, size_t), void * data, int * col,
 				   struct mailmime_language * language);
 
@@ -167,6 +170,10 @@ static int mailmime_field_write_driver(int (* do_write)(void *, const char *, si
 
   case MAILMIME_FIELD_LANGUAGE:
     r = mailmime_language_write_driver(do_write, data, col, field->fld_data.fld_language);
+    break;
+
+  case MAILMIME_FIELD_LOCATION:
+    r = mailmime_location_write_driver(do_write, data, col, field->fld_data.fld_location);
     break;
 
   default:
@@ -307,6 +314,33 @@ static int mailmime_encoding_write_driver(int (* do_write)(void *, const char *,
   * col = 0;
 #endif
   
+  return MAILIMF_NO_ERROR;
+}
+
+static int mailmime_location_write_driver(int (* do_write)(void *, const char *, size_t), void *data, int *col,
+                                   char *location)
+{
+  int r;
+  int len = strlen(location);
+
+  r = mailimf_string_write_driver(do_write, data, col, "Content-Location: ", 18);
+  if (r != MAILIMF_NO_ERROR)
+    return r;
+
+  if (*col > 1 && *col + len > MAX_MAIL_COL) {
+    r = mailimf_string_write_driver(do_write, data, col, "\r\n ", 3);
+    if (r != MAILIMF_NO_ERROR)
+      return r;
+  }
+
+  r = mailimf_string_write_driver(do_write, data, col, location, len);
+  if (r != MAILIMF_NO_ERROR)
+    return r;
+
+  r = mailimf_string_write_driver(do_write, data, col, "\r\n", 2);
+  if (r != MAILIMF_NO_ERROR)
+    return r;
+
   return MAILIMF_NO_ERROR;
 }
 

--- a/Vendor/libetpan/src/low-level/pop3/mailpop3.c
+++ b/Vendor/libetpan/src/low-level/pop3/mailpop3.c
@@ -959,6 +959,14 @@ int mailpop3_stls(mailpop3 * f)
 
   if (r != RESPONSE_OK)
     return MAILPOP3_ERROR_STLS_NOT_SUPPORTED;
+
+  // Detect if the server send extra data after the STLS response.
+  // This *may* be a "response injection attack".
+  if (f->pop3_stream->read_buffer_len != 0) {
+    // Since it is also protocol violation, exit.
+    // There is no error type for STARTTLS errors in POP3
+    return MAILPOP3_ERROR_SSL;
+  }
   
   return MAILPOP3_NO_ERROR;
 }

--- a/Vendor/libetpan/src/low-level/smtp/mailsmtp.c
+++ b/Vendor/libetpan/src/low-level/smtp/mailsmtp.c
@@ -1121,6 +1121,14 @@ int mailesmtp_starttls(mailsmtp * session)
     return MAILSMTP_ERROR_STREAM;
   r = read_response(session);
 
+  // Detect if the server send extra data after the STARTTLS response.
+  // This *may* be a "response injection attack".
+  if (session->stream->read_buffer_len != 0) {
+    // Since it is also protocol violation, exit.
+    // There is no general error type for STARTTLS errors in SMTP
+    return MAILSMTP_ERROR_SSL;
+  }
+
   switch (r) {
   case 220:
     return MAILSMTP_NO_ERROR;

--- a/Vendor/libetpan/tests/frm-simple.c
+++ b/Vendor/libetpan/tests/frm-simple.c
@@ -59,7 +59,7 @@ static void simple_print_mail_info(mailmessage * msg)
 
   strip_crlf(dsp_subject);
 
-  snprintf(output, MAX_OUTPUT, "%3i: %-21.21s %-53.53s\n",
+  snprintf(output, MAX_OUTPUT, "%3i: %-21.21s %-52.52s\n",
       msg->msg_index % 1000, dsp_from, dsp_subject);
   
   printf("%s\n", output);

--- a/Vendor/mailcore2/src/core/abstract/MCMessageConstants.h
+++ b/Vendor/mailcore2/src/core/abstract/MCMessageConstants.h
@@ -70,13 +70,14 @@ namespace mailcore {
         IMAPMessagesRequestKindHeaders       = 1 << 1,
         IMAPMessagesRequestKindStructure     = 1 << 2,
         IMAPMessagesRequestKindInternalDate  = 1 << 3,
-        IMAPMessagesRequestKindFullHeaders   = 1 << 4,
+        IMAPMessagesRequestKindFullHeaders   = 1 << 4, //Fetches the non-parsed list of a limited set of headers.
         IMAPMessagesRequestKindHeaderSubject = 1 << 5,
         IMAPMessagesRequestKindGmailLabels   = 1 << 6,
         IMAPMessagesRequestKindGmailMessageID = 1 << 7,
         IMAPMessagesRequestKindGmailThreadID  = 1 << 8,
         IMAPMessagesRequestKindExtraHeaders  = 1 << 9,
         IMAPMessagesRequestKindSize          = 1 << 10,
+        IMAPMessagesRequestKindAllHeaders    = 1 << 11, // Unlike Full headers this will fetch all the non-parsed headers
     };
     
     enum IMAPFetchRequestType {

--- a/Vendor/mailcore2/src/java/com/libmailcore/IMAPMessagesRequestKind.java
+++ b/Vendor/mailcore2/src/java/com/libmailcore/IMAPMessagesRequestKind.java
@@ -34,4 +34,6 @@ public class IMAPMessagesRequestKind {
     public final static int IMAPMessagesRequestKindExtraHeaders = 1 << 9;
     /** Requests the size of the messages. */
     public final static int IMAPMessagesRequestKindSize = 1 << 10;
+    /** Unlike Full headers this will fetch all the non-parsed headers */
+    public final static int IMAPMessagesRequestKindSize = 1 << 11;
 }

--- a/Vendor/mailcore2/src/java/native/com_libmailcore_IMAPMessagesRequestKind.h
+++ b/Vendor/mailcore2/src/java/native/com_libmailcore_IMAPMessagesRequestKind.h
@@ -31,6 +31,8 @@ extern "C" {
 #define com_libmailcore_IMAPMessagesRequestKind_IMAPMessagesRequestKindExtraHeaders 512L
 #undef com_libmailcore_IMAPMessagesRequestKind_IMAPMessagesRequestKindSize
 #define com_libmailcore_IMAPMessagesRequestKind_IMAPMessagesRequestKindSize 1024L
+#undef com_libmailcore_IMAPMessagesRequestKind_IMAPMessagesRequestKindAllHeaders
+#define com_libmailcore_IMAPMessagesRequestKind_IMAPMessagesRequestKindAllHeaders 2048L
 #ifdef __cplusplus
 }
 #endif

--- a/Vendor/mailcore2/src/objc/abstract/MCOConstants.h
+++ b/Vendor/mailcore2/src/objc/abstract/MCOConstants.h
@@ -149,6 +149,8 @@ typedef NS_OPTIONS(NSInteger, MCOIMAPMessagesRequestKind) {
     MCOIMAPMessagesRequestKindExtraHeaders   = 1 << 9,
     /* Request size of message */
     MCOIMAPMessagesRequestKindSize           = 1 << 10,
+    /* Unlike Full headers this will fetch all the non-parsed headers */
+    MCOIMAPMessagesRequestKindAllHeaders           = 1 << 11,
 
 };
 

--- a/docs/vendor-update-workflow.md
+++ b/docs/vendor-update-workflow.md
@@ -1,0 +1,118 @@
+# Vendor Library Update Workflow
+
+This document describes the process for cherry-picking upstream bug fixes and improvements into vendored dependencies (mailcore2, libetpan) while preserving local modifications.
+
+## Overview
+
+The vendored libraries in `Vendor/` contain local modifications specific to Mailspring. When updating these libraries, we cherry-pick only relevant upstream commits rather than rebasing entirely, to avoid conflicts with local changes.
+
+## Process
+
+### 1. Identify Local Changes
+
+First, identify all commits that have modified the vendor library:
+
+```bash
+git log --oneline -- Vendor/<library>/
+```
+
+Review each commit to understand what local modifications exist and why they were made.
+
+### 2. Identify Base Version
+
+Check the library's version files (e.g., `podspec.json`, `VERSION`, `README.md`) to determine the base upstream version:
+
+```bash
+grep -r "version" Vendor/<library>/*.json
+```
+
+### 3. Analyze Upstream Commits
+
+Clone the upstream repository and list commits since the base version:
+
+```bash
+git clone --depth=100 https://github.com/<org>/<repo>.git /tmp/<repo>-upstream
+cd /tmp/<repo>-upstream
+git log --oneline <base-tag>..master
+```
+
+### 4. Categorize Commits
+
+Review each upstream commit and categorize:
+
+**Include:**
+- Security fixes
+- Bug fixes in core functionality
+- New features that benefit the project
+- Updates to vendored sub-dependencies
+
+**Exclude:**
+- Platform-specific changes (Swift/iOS/Android) if not used
+- Build system changes that would conflict with local config
+- Documentation-only changes
+- Changes to wrapper code (Obj-C, Java) if only C++ core is used
+
+### 5. Generate and Apply Patches
+
+For each commit to cherry-pick:
+
+```bash
+# Generate patch
+cd /tmp/<repo>-upstream
+git format-patch -1 <commit-sha> -o /tmp/patches/
+
+# Check if patch applies cleanly
+cd /path/to/project
+git apply --check --directory=Vendor/<library> -p1 /tmp/patches/<patch-file>
+
+# Apply patch
+git apply --directory=Vendor/<library> -p1 /tmp/patches/<patch-file>
+```
+
+### 6. Commit and Document
+
+Create a commit with detailed documentation of what was cherry-picked:
+
+```bash
+git add Vendor/<library>/
+git commit -m "Cherry-pick upstream <library> bug fixes and improvements
+
+Cherry-picked commits:
+1. <sha> - <description>
+2. <sha> - <description>
+...
+
+Excluded: <reason for exclusions>
+"
+```
+
+## Example: mailcore2 Update (Dec 2025)
+
+### Base Version
+- v0.6.4 (August 2020)
+
+### Local Modifications (15 commits)
+- Plaintext rendering changes (`MCHTMLRenderer.cpp`)
+- SMTP HELO/EHLO fixes
+- Certificate error logging improvements
+- SMTP test email fix
+- Build configuration updates
+
+### Cherry-picked from Upstream
+1. `fad23d73` - SSL Certificate checking in IMAP StartTLS (Security)
+2. `cccebc79` - IMAPMessagesRequestKindFullHeaders fix (Bug)
+3. `29f9488a` - IMAPMessagesRequestKindAllHeaders flag (Feature)
+
+### Excluded
+- Swift Package Manager changes (not used)
+- Android build updates (not used)
+- Objective-C NSCoding fix (C++ core only)
+- Xcode 13+ build fixes (would conflict with local config)
+- Documentation updates
+
+## Notes
+
+- Always test builds after applying patches
+- Keep the upstream clone available during review
+- Document exclusions for future reference
+- Consider upstream activity level - dormant repos may not need frequent updates


### PR DESCRIPTION
Cherry-picked the following commits from upstream MailCore/mailcore2:

1. fad23d73 - Ensure checking SSL Certificate in IMAP StartTLS
   Security fix: adds certificate validation after StartTLS connection
   to close a potential security gap where certificate validation
   wasn't being performed in that connection mode.

2. cccebc79 - Fix IMAPMessagesRequestKindFullHeaders handling (#1947)
   Bug fix: properly handles the FullHeaders flag when fetching
   messages by UID, fetching complete headers when the flag is set.

3. 29f9488a - Add IMAPMessagesRequestKindAllHeaders flag
   New feature: adds a new flag to fetch all non-parsed headers,
   unlike FullHeaders which fetches a limited set.

These are the only relevant commits since v0.6.4 (Aug 2020) through
Nov 2022 that are bug fixes or functionality improvements for the
C++ core. Excluded: Swift/SPM changes, Android changes, Obj-C specific
fixes, documentation updates, and Xcode project changes.