### PR TITLE
Add test infrastructure and CI workflow for running tests on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y \
+            build-essential cmake \
+            libglib2.0-dev
+
+      - name: Configure CMake with tests
+        run: |
+          mkdir -p build
+          cd build
+          cmake .. -DMAILSYNC_BUILD_TESTS=ON -DMAILSYNC_TESTS_ONLY=ON
+
+      - name: Build tests
+        run: |
+          cd build
+          make -j$(nproc)
+
+      - name: Run tests
+        run: |
+          cd build
+          ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,10 @@
-cmake_minimum_required (VERSION 3.1 FATAL_ERROR)
-project (mailsync) 
+cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
+project (mailsync)
 
 SET (CMAKE_CXX_FLAGS   "-Wno-unknown-pragmas")
+
+option(MAILSYNC_BUILD_TESTS "Build and run tests" OFF)
+option(MAILSYNC_TESTS_ONLY "Only build tests, skip mailsync executable" OFF)
 
 #Set Linker flags
 set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
@@ -15,91 +18,165 @@ link_directories (${GLIB_LIBRARY_DIRS})
 
 IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
-  set(additional_includes
-    /usr/include/tidy
-    /usr/include/libxml2
-    /usr/include/curl
-  )
-  
-  set(icu_libraries icudata icui18n icuio icutest icutu icuuc)
-  set(linux_libraries ${icu_libraries} pthread uuid xml2)
+  # Test-only build configuration
+  if(MAILSYNC_BUILD_TESTS)
+    enable_testing()
 
-  link_directories(/opt/openssl/lib)
-  link_directories(Vendor/mailcore2/build/src)
-  include_directories(Vendor/mailcore2/build/src/include)
+    # Find or fetch Google Test
+    find_package(GTest QUIET)
+    if(NOT GTEST_FOUND)
+      include(FetchContent)
+      FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.14.0
+      )
+      set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+      FetchContent_MakeAvailable(googletest)
+    endif()
 
-  include_directories(Vendor)
-  include_directories(Vendor/nlohmann)
-  include_directories(Vendor/icalendarlib)
-  include_directories(Vendor/SQLiteCpp/include Vendor/SQLiteCpp/sqlite3)
-  include_directories(Vendor/StanfordCPPLib)
-  include_directories(MailSync MailSync/Models)
+    # SQLiteCpp test sources
+    set(SQLITECPP_TESTS
+      Vendor/SQLiteCpp/tests/Column_test.cpp
+      Vendor/SQLiteCpp/tests/Database_test.cpp
+      Vendor/SQLiteCpp/tests/Savepoint_test.cpp
+      Vendor/SQLiteCpp/tests/Statement_test.cpp
+      Vendor/SQLiteCpp/tests/Backup_test.cpp
+      Vendor/SQLiteCpp/tests/Transaction_test.cpp
+      Vendor/SQLiteCpp/tests/VariadicBind_test.cpp
+      Vendor/SQLiteCpp/tests/Exception_test.cpp
+      Vendor/SQLiteCpp/tests/ExecuteMany_test.cpp
+    )
 
-  file(GLOB SOURCES
-    MailSync/*.h
-    MailSync/*.[ch]pp
-    MailSync/Models/*.h
-    MailSync/Models/*.[ch]pp
-    Vendor/SQLiteCpp/sqlite3/*.[ch]
-    Vendor/SQLiteCpp/src/*.[ch]pp
-    Vendor/icalendarlib/*.h
-    Vendor/icalendarlib/*.cpp
-    Vendor/StanfordCPPLib/*.[ch]pp
-    Vendor/StanfordCPPLib/stacktrace/*.[ch]pp
-  )
+    # Build a static library for SQLiteCpp to link tests against
+    add_library(SQLiteCpp_lib STATIC
+      Vendor/SQLiteCpp/src/Backup.cpp
+      Vendor/SQLiteCpp/src/Column.cpp
+      Vendor/SQLiteCpp/src/Database.cpp
+      Vendor/SQLiteCpp/src/Exception.cpp
+      Vendor/SQLiteCpp/src/Savepoint.cpp
+      Vendor/SQLiteCpp/src/Statement.cpp
+      Vendor/SQLiteCpp/src/Transaction.cpp
+      Vendor/SQLiteCpp/sqlite3/sqlite3.c
+    )
+    target_include_directories(SQLiteCpp_lib PUBLIC
+      Vendor/SQLiteCpp/include
+      Vendor/SQLiteCpp/sqlite3
+    )
+    target_compile_definitions(SQLiteCpp_lib PUBLIC
+      SQLITE_ENABLE_COLUMN_METADATA
+      SQLITE_ENABLE_FTS5=1
+    )
+    set_target_properties(SQLiteCpp_lib PROPERTIES COMPILE_FLAGS "-fPIC")
 
-  add_executable(mailsync MailSync/main.cpp ${SOURCES})
+    # Build the test executable
+    add_executable(mailsync_tests ${SQLITECPP_TESTS})
+    target_include_directories(mailsync_tests PRIVATE
+      Vendor/SQLiteCpp/include
+      Vendor/SQLiteCpp/sqlite3
+    )
+    target_link_libraries(mailsync_tests SQLiteCpp_lib)
+    if(GTEST_FOUND)
+      target_link_libraries(mailsync_tests GTest::GTest GTest::Main)
+    else()
+      target_link_libraries(mailsync_tests gtest_main)
+    endif()
+    target_link_libraries(mailsync_tests pthread dl)
 
-  add_definitions(-DSQLITE_ENABLE_FTS5=1 -DHAVE_USLEEP=1 -DSQLITE_OMIT_LOAD_EXTENSION=1)
+    # Register tests with CTest
+    add_test(NAME SQLiteCppTests COMMAND mailsync_tests)
+  endif()
 
-  target_link_libraries(mailsync libMailCore.a)
-  target_link_libraries(mailsync ${GLIB_LIBRARIES})
-  target_link_libraries(mailsync libetpan.a)
+  # Skip mailsync build if only building tests
+  if(NOT MAILSYNC_TESTS_ONLY)
 
-  find_library(XML_LIB NAMES libxml2.a libxml2)
-  target_link_libraries(mailsync ${XML_LIB})
-  target_include_directories(mailsync PRIVATE /usr/include/libxml2)
+    set(additional_includes
+      /usr/include/tidy
+      /usr/include/libxml2
+      /usr/include/curl
+    )
 
-  find_library(LZMA_LIB NAMES liblzma.a liblzma)
-  target_link_libraries(mailsync ${LZMA_LIB})
+    set(icu_libraries icudata icui18n icuio icutest icutu icuuc)
+    set(linux_libraries ${icu_libraries} pthread uuid xml2)
 
-  find_library(Z_LIB NAMES libz.a libz)
-  target_link_libraries(mailsync ${Z_LIB})
+    link_directories(/opt/openssl/lib)
+    link_directories(Vendor/mailcore2/build/src)
+    include_directories(Vendor/mailcore2/build/src/include)
 
-  find_library(RESOLV_LIB NAMES libresolv.a libresolv)
-  target_link_libraries(mailsync ${RESOLV_LIB})
+    include_directories(Vendor)
+    include_directories(Vendor/nlohmann)
+    include_directories(Vendor/icalendarlib)
+    include_directories(Vendor/SQLiteCpp/include Vendor/SQLiteCpp/sqlite3)
+    include_directories(Vendor/StanfordCPPLib)
+    include_directories(MailSync MailSync/Models)
 
-  find_library(CTEMPLATE_LIB NAMES libctemplate.a libctemplate)
-  target_link_libraries(mailsync ${CTEMPLATE_LIB})
+    file(GLOB SOURCES
+      MailSync/*.h
+      MailSync/*.[ch]pp
+      MailSync/Models/*.h
+      MailSync/Models/*.[ch]pp
+      Vendor/SQLiteCpp/sqlite3/*.[ch]
+      Vendor/SQLiteCpp/src/*.[ch]pp
+      Vendor/icalendarlib/*.h
+      Vendor/icalendarlib/*.cpp
+      Vendor/StanfordCPPLib/*.[ch]pp
+      Vendor/StanfordCPPLib/stacktrace/*.[ch]pp
+    )
 
-  find_library(UUID_LIB NAMES libuuid.a libuuid)
-  target_link_libraries(mailsync ${UUID_LIB})
+    add_executable(mailsync MailSync/main.cpp ${SOURCES})
 
-  find_library(ICUI18N_LIB NAMES libicui18n.a libicui18n)
-  target_link_libraries(mailsync ${ICUI18N_LIB})
+    add_definitions(-DSQLITE_ENABLE_FTS5=1 -DHAVE_USLEEP=1 -DSQLITE_OMIT_LOAD_EXTENSION=1)
 
-  find_library(ICUUC_LIB NAMES libicuuc.a libicuuc)
-  target_link_libraries(mailsync ${ICUUC_LIB})
+    target_link_libraries(mailsync libMailCore.a)
+    target_link_libraries(mailsync ${GLIB_LIBRARIES})
+    target_link_libraries(mailsync libetpan.a)
 
-  find_library(ICUDATA_LIB NAMES libicudata.a libicudata)
-  target_link_libraries(mailsync ${ICUDATA_LIB})
+    find_library(XML_LIB NAMES libxml2.a libxml2)
+    target_link_libraries(mailsync ${XML_LIB})
+    target_include_directories(mailsync PRIVATE /usr/include/libxml2)
 
-  find_library(C_ARES_LIB NAMES libcares.a libcares)
-  target_link_libraries(mailsync ${C_ARES_LIB})
+    find_library(LZMA_LIB NAMES liblzma.a liblzma)
+    target_link_libraries(mailsync ${LZMA_LIB})
 
-  #find_library(SASL2_LIB NAMES libsasl2.a libsasl2)
-  #target_link_libraries(mailsync ${SASL2_LIB})
+    find_library(Z_LIB NAMES libz.a libz)
+    target_link_libraries(mailsync ${Z_LIB})
 
-  #find_library(SASLEXTRA_LIB NAMES libgssapi.a libgssapi)
-  #target_link_libraries(mailsync ${SASLEXTRA_LIB})
+    find_library(RESOLV_LIB NAMES libresolv.a libresolv)
+    target_link_libraries(mailsync ${RESOLV_LIB})
 
-  #find_library(DL_LIB NAMES libdl.a libdl)
-  #target_link_libraries(mailsync ${DL_LIB})
+    find_library(CTEMPLATE_LIB NAMES libctemplate.a libctemplate)
+    target_link_libraries(mailsync ${CTEMPLATE_LIB})
 
-  #find_library(RT_LIB NAMES librt.a librt)
-  #target_link_libraries(mailsync ${RT_LIB})
+    find_library(UUID_LIB NAMES libuuid.a libuuid)
+    target_link_libraries(mailsync ${UUID_LIB})
 
-  # These dynamic links are the packages that must be on the host machine
-  target_link_libraries(mailsync pthread sasl2 ssl crypto tidy curl dl)
+    find_library(ICUI18N_LIB NAMES libicui18n.a libicui18n)
+    target_link_libraries(mailsync ${ICUI18N_LIB})
+
+    find_library(ICUUC_LIB NAMES libicuuc.a libicuuc)
+    target_link_libraries(mailsync ${ICUUC_LIB})
+
+    find_library(ICUDATA_LIB NAMES libicudata.a libicudata)
+    target_link_libraries(mailsync ${ICUDATA_LIB})
+
+    find_library(C_ARES_LIB NAMES libcares.a libcares)
+    target_link_libraries(mailsync ${C_ARES_LIB})
+
+    #find_library(SASL2_LIB NAMES libsasl2.a libsasl2)
+    #target_link_libraries(mailsync ${SASL2_LIB})
+
+    #find_library(SASLEXTRA_LIB NAMES libgssapi.a libgssapi)
+    #target_link_libraries(mailsync ${SASLEXTRA_LIB})
+
+    #find_library(DL_LIB NAMES libdl.a libdl)
+    #target_link_libraries(mailsync ${DL_LIB})
+
+    #find_library(RT_LIB NAMES librt.a librt)
+    #target_link_libraries(mailsync ${RT_LIB})
+
+    # These dynamic links are the packages that must be on the host machine
+    target_link_libraries(mailsync pthread sasl2 ssl crypto tidy curl dl)
+
+  endif()
 
 ENDIF()

--- a/Vendor/SQLiteCpp/tests/Statement_test.cpp
+++ b/Vendor/SQLiteCpp/tests/Statement_test.cpp
@@ -331,7 +331,7 @@ TEST(Statement, bindings)
         const int64_t       int64 = 12345678900000LL;
         const float         float32 = 0.234f;
         insert.bind(1, fourth);
-        insert.bind(2, int64);
+        insert.bind(2, static_cast<long long int>(int64));
         insert.bind(3, float32);
         EXPECT_EQ(1, insert.exec());
         EXPECT_EQ(SQLITE_DONE, db.getErrorCode());
@@ -376,7 +376,7 @@ TEST(Statement, bindings)
         const uint32_t  uint32 = 4294967295U;
         const int64_t   integer = -123;
         insert.bind(2, uint32);
-        insert.bind(3, integer);
+        insert.bind(3, static_cast<long long int>(integer));
         EXPECT_EQ(1, insert.exec());
         EXPECT_EQ(SQLITE_DONE, db.getErrorCode());
 
@@ -396,7 +396,7 @@ TEST(Statement, bindings)
     // Seventh row using another variant of int64 type
     {
         const int64_t   int64 = 12345678900000LL;
-        insert.bind(2, int64);
+        insert.bind(2, static_cast<long long int>(int64));
         EXPECT_EQ(1, insert.exec());
         EXPECT_EQ(SQLITE_DONE, db.getErrorCode());
 
@@ -497,7 +497,7 @@ TEST(Statement, bindByName)
         const float         float32 = 0.234f;
         insert.bind("@msg",      second);
         insert.bind("@int",      int32);
-        insert.bind("@long",     int64);
+        insert.bind("@long",     static_cast<long long int>(int64));
         insert.bind("@double",   float32);
         EXPECT_EQ(1, insert.exec());
         EXPECT_EQ(SQLITE_DONE, db.getErrorCode());
@@ -542,7 +542,7 @@ TEST(Statement, bindByName)
         const uint32_t  uint32 = 4294967295U;
         const int64_t   int64 = 12345678900000LL;
         insert.bind("@int", uint32);
-        insert.bind("@long", int64);
+        insert.bind("@long", static_cast<long long int>(int64));
         EXPECT_EQ(1, insert.exec());
         EXPECT_EQ(SQLITE_DONE, db.getErrorCode());
 
@@ -609,9 +609,9 @@ TEST(Statement, bindByNameString)
         const int64_t       integer = -123;
         const float         float32 = 0.234f;
         insert.bind(amsg, second);
-        insert.bind(aint, int64);
+        insert.bind(aint, static_cast<long long int>(int64));
         insert.bind(adouble, float32);
-        insert.bind(along, integer);
+        insert.bind(along, static_cast<long long int>(integer));
         EXPECT_EQ(1, insert.exec());
         EXPECT_EQ(SQLITE_DONE, db.getErrorCode());
 
@@ -655,7 +655,7 @@ TEST(Statement, bindByNameString)
         const uint32_t  uint32 = 4294967295U;
         const int64_t   int64 = 12345678900000LL;
         insert.bind(aint, uint32);
-        insert.bind(along, int64);
+        insert.bind(along, static_cast<long long int>(int64));
         EXPECT_EQ(1, insert.exec());
         EXPECT_EQ(SQLITE_DONE, db.getErrorCode());
 


### PR DESCRIPTION
- Update CMakeLists.txt with MAILSYNC_BUILD_TESTS and MAILSYNC_TESTS_ONLY
  options to enable building SQLiteCpp unit tests independently
- Fix int64_t ambiguous overload issues in Statement_test.cpp for
  64-bit Linux platforms by adding explicit casts to long long int
- Add .github/workflows/test.yml to run tests on PRs and pushes
- Tests use Google Test framework (fetched via FetchContent)