### PR TITLE
Switch macOS builds to macos-latest (arm64) with universal binary support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, macos-latest]
         include:
           - os: ubuntu-22.04
-          - os: macos-13
-            osx_image: xcode13.2
+          - os: macos-latest
 
     steps:
       - name: Checkout code
@@ -59,6 +58,26 @@ jobs:
 
       - name: Run build script
         run: ./build.sh
+
+      - name: Verify universal binary architectures (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          echo "Verifying mailsync binary architectures..."
+          ARCHS=$(lipo -archs ../app/mailsync)
+          echo "Architectures found: $ARCHS"
+
+          if [[ "$ARCHS" != *"arm64"* ]]; then
+            echo "ERROR: arm64 architecture not found in binary"
+            exit 1
+          fi
+
+          if [[ "$ARCHS" != *"x86_64"* ]]; then
+            echo "ERROR: x86_64 architecture not found in binary"
+            exit 1
+          fi
+
+          echo "Universal binary verification passed: $ARCHS"
+          lipo -info ../app/mailsync
 
       - name: Setup AWS CLI
         if: success() && (github.ref == 'refs/heads/master')

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,8 @@ mkdir -p "$APP_DIST_DIR"
 if [[ "$OSTYPE" == "darwin"* ]]; then
   cd "$MAILSYNC_DIR"
   gem install xcpretty;
-  set -o pipefail && xcodebuild -scheme mailsync -configuration Release -destination 'generic/platform=macOS' | xcpretty;
+  # Build universal binary for both arm64 and x86_64
+  set -o pipefail && xcodebuild -scheme mailsync -configuration Release -destination 'generic/platform=macOS' ONLY_ACTIVE_ARCH=NO ARCHS="arm64 x86_64" | xcpretty;
 
   # the xcodebuild copies the build products to the APP_ROOT_DIR and codesigns
   # them for us. We just need to tar them up and move them to the artifacts folder


### PR DESCRIPTION
- Update GitHub Actions to use macos-latest runner (macOS 15 arm64)
- Configure xcodebuild to build universal binaries for both arm64 and x86_64
- Add lipo verification step to ensure both architectures are present before upload