### PR TITLE
Fix operator precedence in poll() result checks

### DIFF
--- a/Vendor/libetpan/src/data-types/connect.c
+++ b/Vendor/libetpan/src/data-types/connect.c
@@ -159,7 +159,7 @@ static int wait_connect(int s, int r, time_t timeout_seconds)
     return -1;
   }
   
-  if (pfd.revents & POLLOUT != POLLOUT) {
+  if ((pfd.revents & POLLOUT) != POLLOUT) {
     return -1;
   }
 #endif

--- a/Vendor/libetpan/src/data-types/mailstream_ssl.c
+++ b/Vendor/libetpan/src/data-types/mailstream_ssl.c
@@ -362,7 +362,7 @@ static int wait_SSL_connect(int s, int want_read, time_t timeout_seconds)
     return -1;
   }
 
-  if (pfd.revents & pfd.events != pfd.events) {
+  if ((pfd.revents & pfd.events) != pfd.events) {
     return -1;
   }
 #endif


### PR DESCRIPTION
Cherry-pick fix from upstream libetpan PR #447. 

The expressions `pfd.revents & POLLOUT != POLLOUT` and `pfd.revents & pfd.events != pfd.events` have incorrect operator precedence. The `!=` operator has higher precedence than `&`, so these evaluate as `pfd.revents & (POLLOUT != POLLOUT)` which is always 0.

This fix adds parentheses to ensure correct evaluation: `(pfd.revents & POLLOUT) != POLLOUT`

Upstream: https://github.com/dinhvh/libetpan/pull/447