### PR TITLE
Fix double-free in charconv when extended_charconv fails

### DIFF
--- a/Vendor/libetpan/src/data-types/charconv.c
+++ b/Vendor/libetpan/src/data-types/charconv.c
@@ -173,6 +173,7 @@ int charconv(const char * tocode, const char * fromcode,
 			res = (*extended_charconv)( tocode, fromcode, str, length, *result, &result_length);
 			if (res != MAIL_CHARCONV_NO_ERROR) {
 				free( *result);
+				*result = NULL;
 			} else {
 				out = realloc( *result, result_length + 1);
 				if (out != NULL) *result = out;


### PR DESCRIPTION
Cherry-pick fix from upstream libetpan PR #436.

When extended_charconv fails (e.g., iconv failure on iOS 17+), the allocated result buffer is freed but the pointer is not set to NULL. If the caller later frees the same pointer, this causes a double-free crash.

Setting *result = NULL after free() prevents the double-free by ensuring subsequent free() calls on the pointer are safe no-ops.

Upstream: https://github.com/dinhvh/libetpan/pull/436