### PR TITLE
Fix potential infinite loop in mailstorage_disconnect

### DIFF
--- a/Vendor/libetpan/src/driver/interface/mailstorage.c
+++ b/Vendor/libetpan/src/driver/interface/mailstorage.c
@@ -320,7 +320,7 @@ void mailstorage_disconnect(struct mailstorage * storage)
 {
   clistiter * cur;
 
-  while ((cur = clist_begin(storage->sto_shared_folders)) != NULL) {
+  for (cur = clist_begin(storage->sto_shared_folders); cur != NULL; cur = clist_next(cur)) {
     struct mailfolder * folder;
 
     folder = cur->data;


### PR DESCRIPTION
Cherry-pick fix from upstream libetpan PR #369.

The while loop pattern `while ((cur = clist_begin(...)) != NULL)` assumes that each iteration removes an element from the list. If mailfolder_disconnect() doesn't remove the folder from sto_shared_folders, this becomes an infinite loop.

Using a standard for-loop iteration pattern is safer and follows the idiomatic clist traversal used elsewhere in the codebase.

Upstream: https://github.com/dinhvh/libetpan/pull/369