### PR TITLE
Fix SMTP EHLO/HELO with IPv6 addresses on Linux

### DIFF
--- a/Vendor/libetpan/src/low-level/smtp/mailsmtp.c
+++ b/Vendor/libetpan/src/low-level/smtp/mailsmtp.c
@@ -279,12 +279,18 @@ static int get_hostname(mailsmtp * session, int useip, char * buf, int len)
       return MAILSMTP_ERROR_HOSTNAME;
 
 #if (defined __linux__ || defined WIN32 || defined __sun)
-    r = getnameinfo(&addr, sizeof(addr), hostname, HOSTNAME_SIZE, NULL, 0, NI_NUMERICHOST);
+    r = getnameinfo(&addr, addr_len, hostname, HOSTNAME_SIZE, NULL, 0, NI_NUMERICHOST);
 #else
     r = getnameinfo(&addr, addr.sa_len, hostname, HOSTNAME_SIZE, NULL, 0, NI_NUMERICHOST);
 #endif
     if (r != 0)
       return MAILSMTP_ERROR_HOSTNAME;
+
+    /* Strip IPv6 interface suffix (e.g., "%eth0") which some servers reject */
+    char* interface_suffix = strstr(hostname, "%");
+    if (interface_suffix != NULL) {
+      *interface_suffix = '\0';
+    }
 
     if (snprintf(buf, len, "[%s]", hostname) >= len)
       return MAILSMTP_ERROR_HOSTNAME;


### PR DESCRIPTION
Cherry-pick fix from upstream libetpan PR #433.

Two issues prevented SMTP from working correctly with IPv6 on Linux:

1. getnameinfo() was called with sizeof(addr) (always 16 bytes) instead of addr_len which contains the actual address length from getsockname(). This caused EAI_FAMILY errors for IPv6 addresses.

2. IPv6 addresses may include an interface suffix (e.g., "%eth0") which Gmail and other servers reject with errors like: "501-5.5.4 HELO/EHLO argument [2400:...:0%808590000] invalid"

   The fix strips the interface suffix before sending the address.

Upstream: https://github.com/dinhvh/libetpan/pull/433