### PR TITLE
Prevent undefined behavior when socket descriptor exceeds FD_SETSIZE

### DIFF
--- a/Vendor/libetpan/src/data-types/mailstream_ssl.c
+++ b/Vendor/libetpan/src/data-types/mailstream_ssl.c
@@ -335,6 +335,9 @@ static int wait_SSL_connect(int s, int want_read, time_t timeout_seconds)
     timeout.tv_usec = 0;
   }
 #if defined(WIN32) || !USE_POLL
+  if (s >= FD_SETSIZE) {
+    return -1;
+  }
   FD_ZERO(&fds);
   FD_SET(s, &fds);
   /* TODO: how to cancel this ? */


### PR DESCRIPTION
Cherry-pick fix from upstream libetpan PR #427.

When there are many open file descriptors (e.g., due to connection leaks or high concurrency), socket descriptors can exceed FD_SETSIZE (typically 1024). Using FD_SET with such descriptors causes undefined behavior and can corrupt memory or trigger runtime checks like glibc's __fdelt_chk.

This fix adds a bounds check before FD_SET to fail gracefully instead of causing undefined behavior.

Note: Only the bug fix is cherry-picked; the unrelated configure.ac optimization level change from the original PR is not included.

Upstream: https://github.com/dinhvh/libetpan/pull/427