### PR TITLE
Fix incomplete revert of broken IMF quoted string parsing

### DIFF
--- a/Vendor/libetpan/src/low-level/imf/mailimf.c
+++ b/Vendor/libetpan/src/low-level/imf/mailimf.c
@@ -1431,9 +1431,7 @@ int mailimf_quoted_string_parse(const char * message, size_t length,
         goto free_gstr;
       }
     }
-    else if (r == MAILIMF_ERROR_PARSE)
-      break;
-    else {
+    else if (r != MAILIMF_ERROR_PARSE) {
       res = r;
       goto free_gstr;
     }
@@ -1528,15 +1526,13 @@ int mailimf_fws_quoted_string_parse(const char * message, size_t length,
         goto free_gstr;
       }
     }
-    else if (r == MAILIMF_ERROR_PARSE)
-      break;
-    else {
+    else if (r != MAILIMF_ERROR_PARSE) {
       res = r;
       goto free_gstr;
     }
-    }
+  }
 
-    r = mailimf_dquote_parse(message, length, &cur_token);
+  r = mailimf_dquote_parse(message, length, &cur_token);
     if (r != MAILIMF_NO_ERROR) {
       res = r;
       goto free_gstr;


### PR DESCRIPTION
Cherry-pick fix from upstream libetpan PR #411.

A previous incomplete revert left broken error handling patterns in mailimf_quoted_string_parse and mailimf_fws_quoted_string_parse.

The pattern `else if (r == MAILIMF_ERROR_PARSE) break; else { error }` incorrectly breaks out of the parsing loop on parse errors. The correct pattern is `else if (r != MAILIMF_ERROR_PARSE) { error }` which only handles actual errors while allowing MAILIMF_ERROR_PARSE to continue the loop naturally.

This restores the original working behavior of IMF field parsing.

Upstream: https://github.com/dinhvh/libetpan/pull/411
Related: https://github.com/dinhvh/libetpan/issues/406