### PR TITLE
Handle empty IMAP parts from Outlook.com servers

### DIFF
--- a/Vendor/mailcore2/src/core/imap/MCIMAPSession.h
+++ b/Vendor/mailcore2/src/core/imap/MCIMAPSession.h
@@ -277,7 +277,8 @@ namespace mailcore {
         bool mRamblerRuServer;
         bool mHermesServer;
         bool mQipServer;
-        
+        bool mOutlookServer;
+
         unsigned int mLastFetchedSequenceNumber;
         String * mCurrentFolder;
         pthread_mutex_t mIdleLock;
@@ -326,6 +327,10 @@ namespace mailcore {
                                       bool wholePart, uint32_t offset, uint32_t length,
                                       Encoding encoding, IMAPProgressCallback * progressCallback, ErrorCode * pError);
         void storeLabels(String * folder, bool identifier_is_uid, IndexSet * identifiers, IMAPStoreFlagsRequestKind kind, Array * labels, ErrorCode * pError);
+        int fetch_imap(struct mailimap * imap, bool identifier_is_uid, uint32_t identifier,
+                       struct mailimap_fetch_type * fetch_type, char ** result, size_t * result_len);
+        int fetch_rfc822(struct mailimap * session, bool identifier_is_uid,
+                         uint32_t identifier, char ** result, size_t * result_len);
     };
 
 }


### PR DESCRIPTION
Cherry-pick fix from upstream mailcore2 PR #1621.

Outlook.com IMAP server sometimes omits message parts and returns them as zero-length when there is a vCalendar part in the message. Previously this would cause a MAILIMAP_ERROR_FETCH error, failing the entire fetch.

This fix:
1. Adds mOutlookServer detection based on hostname
2. When fetching from Outlook and encountering a NULL/empty part, returns zero-length data instead of an error

This allows messages with vCalendar attachments to be fetched successfully from Outlook.com accounts.

Upstream: https://github.com/MailCore/mailcore2/pull/1621