### PR TITLE
Replace deprecated OSSpinLock with pthread_mutex_t

### DIFF
--- a/Vendor/mailcore2/src/core/basetypes/MCLock.h
+++ b/Vendor/mailcore2/src/core/basetypes/MCLock.h
@@ -9,24 +9,11 @@
 #ifndef mailcore2_MCLock_h
 #define mailcore2_MCLock_h
 
-#if __APPLE__
-
-#include <libkern/OSAtomic.h>
-
-#define MC_LOCK_TYPE OSSpinLock
-#define MC_LOCK_INITIAL_VALUE OS_SPINLOCK_INIT
-#define MC_LOCK(l) OSSpinLockLock(l)
-#define MC_UNLOCK(l) OSSpinLockUnlock(l)
-
-#else
-
 #include <pthread.h>
 
 #define MC_LOCK_TYPE pthread_mutex_t
 #define MC_LOCK_INITIAL_VALUE PTHREAD_MUTEX_INITIALIZER
 #define MC_LOCK(l) pthread_mutex_lock(l)
 #define MC_UNLOCK(l) pthread_mutex_unlock(l)
-
-#endif
 
 #endif

--- a/Vendor/mailcore2/src/core/basetypes/MCObject.cpp
+++ b/Vendor/mailcore2/src/core/basetypes/MCObject.cpp
@@ -33,18 +33,12 @@ Object::Object()
 
 Object::~Object()
 {
-#ifndef __APPLE__
     pthread_mutex_destroy(&mLock);
-#endif
 }
 
 void Object::init()
 {
-#if __APPLE__
-    mLock = OS_SPINLOCK_INIT;
-#else
     pthread_mutex_init(&mLock, NULL);
-#endif
     mCounter = 1;
 }
 

--- a/Vendor/mailcore2/src/core/basetypes/MCObject.h
+++ b/Vendor/mailcore2/src/core/basetypes/MCObject.h
@@ -57,11 +57,7 @@ namespace mailcore {
     public: // private
         
     private:
-#if __APPLE__
-        OSSpinLock mLock;
-#else
         pthread_mutex_t mLock;
-#endif
         int mCounter;
         void init();
         static void initObjectConstructors();


### PR DESCRIPTION
Cherry-pick fix from upstream mailcore2 PR #1953.

OSSpinLock is deprecated on Apple platforms since macOS 10.12/iOS 10.0 due to priority inversion issues. This causes deprecation warnings during compilation.

This fix replaces OSSpinLock with pthread_mutex_t on all platforms, which is already used on non-Apple platforms. pthread_mutex_t is a safe, portable alternative that:
1. Avoids priority inversion issues
2. Eliminates platform-specific code paths
3. Is already being used elsewhere in the codebase

Upstream: https://github.com/MailCore/mailcore2/pull/1953
Related: https://github.com/MailCore/mailcore2/issues/1785