### PR TITLE
Fix nlohmann json build error on Windows with MSVC 2015+

### DIFF
--- a/Vendor/libetpan/build-windows/libetpan-config.h
+++ b/Vendor/libetpan/build-windows/libetpan-config.h
@@ -30,7 +30,7 @@
 #		undef  PropVariantInit
 #	endif
 
-#	if !defined(snprintf)
+#	if !defined(snprintf) && _MSC_VER < 1900
 #		define snprintf _snprintf
 #	endif
 #	if !defined(strncasecmp)

--- a/Vendor/mailcore2/Externals/include/libetpan/libetpan-config.h
+++ b/Vendor/mailcore2/Externals/include/libetpan/libetpan-config.h
@@ -30,7 +30,7 @@
 #		undef  PropVariantInit
 #	endif
 
-#	if !defined(snprintf)
+#	if !defined(snprintf) && _MSC_VER < 1900
 #		define snprintf _snprintf
 #	endif
 #	if !defined(strncasecmp)

--- a/Vendor/mailcore2/src/core/basetypes/MCWin32.h
+++ b/Vendor/mailcore2/src/core/basetypes/MCWin32.h
@@ -36,7 +36,9 @@
 #define localtime_r mailcore::win32_localtime_r
 #define gettimeofday mailcore::win32_gettimeofday
 #define getpid mailcore::win32_getpid
+#if _MSC_VER < 1900
 #define snprintf mailcore::win32_snprintf
+#endif
 #define vasprintf mailcore::win32_vasprintf
 #define timegm mailcore::win32_timegm
 #define random mailcore::win32_random


### PR DESCRIPTION
The snprintf macro was unconditionally redefining snprintf to _snprintf,
which broke std::snprintf usage in nlohmann json v3.12.0. This macro is
only needed for MSVC versions before VS2015 (< 1900), which didn't have
a standard-compliant snprintf. Modern MSVC includes snprintf in the
Universal CRT.