### PR TITLE
Fix unnecessary copy in vector iteration

### DIFF
--- a/MailSync/DeltaStream.cpp
+++ b/MailSync/DeltaStream.cpp
@@ -183,7 +183,7 @@ void DeltaStream::emit(DeltaStreamItem item, int maxDeliveryDelay) {
 }
 
 void DeltaStream::emit(vector<DeltaStreamItem> items, int maxDeliveryDelay) {
-    for (const auto item : items) {
+    for (const auto & item : items) {
         queueDeltaForDelivery(item);
     }
     flushWithin(maxDeliveryDelay);


### PR DESCRIPTION
Use const reference instead of copying DeltaStreamItem on each
iteration. This aligns with the pattern used consistently elsewhere
in the codebase and avoids unnecessary copies of objects containing
heap-allocated members (strings, vectors, maps).