### PR TITLE
Initialize connectionError member in DeltaStream constructor

### DIFF
--- a/MailSync/DeltaStream.cpp
+++ b/MailSync/DeltaStream.cpp
@@ -108,7 +108,7 @@ string DeltaStreamItem::dump() const {
 
 // Class
 
-DeltaStream::DeltaStream() : scheduled(false) {
+DeltaStream::DeltaStream() : scheduled(false), connectionError(false) {
 }
 
 


### PR DESCRIPTION
The connectionError bool was not initialized in the constructor,
leaving it with an undefined value. This caused undefined behavior
in endConnectionError() which reads the variable to check if an
error state needs to be cleared. On a successful first connection
(no errors), endConnectionError() would be called before any call
to beginConnectionError(), reading the uninitialized value.