### PR TITLE
Add error check after session.idle() to prevent silent failures

### DIFF
--- a/MailSync/SyncWorker.cpp
+++ b/MailSync/SyncWorker.cpp
@@ -219,6 +219,9 @@ void SyncWorker::idleCycleIteration()
         session.idle(&path, 0, &err);
         session.unsetupIdle();
         logger->info("Idle exited with code {}", err);
+        if (err != ErrorNone) {
+            throw SyncException(err, "idle");
+        }
     } else {
         logger->info("Connection does not support idling. Locking until more to do...");
         std::unique_lock<std::mutex> lck(idleMtx);


### PR DESCRIPTION
The error code from idle() was being logged but not checked. If IDLE
failed with an error (connection drop, authentication issue, etc.),
the loop would silently continue without proper error handling.

Now throws SyncException when idle() returns an error, allowing the
caller in main.cpp to properly handle retryable vs non-retryable errors
(abort, sleep, signal offline status). This matches how all other IMAP
operations in this file handle errors.

Fixes code review finding #3.