### PR TITLE
Fix memory leak in fake IMAPFolder creation during folder sync

### DIFF
--- a/MailSync/SyncWorker.cpp
+++ b/MailSync/SyncWorker.cpp
@@ -559,6 +559,7 @@ vector<shared_ptr<Folder>> SyncWorker::syncFoldersAndLabels()
             }
             logger->error("Created required Mailspring folder: {}.", desiredPath->UTF8Characters());
             IMAPFolder * fake = new IMAPFolder();
+            fake->autorelease();
             fake->setPath(desiredPath);
             fake->setDelimiter(session.defaultNamespace()->mainDelimiter());
             remoteFolders->addObject(fake);


### PR DESCRIPTION
The IMAPFolder created to represent newly created Mailspring folders
was allocated with new but never autoreleased. Since MailCore uses
reference counting, the object's retain count remains at 1 after
remoteFolders releases it, causing a memory leak each time a required
Mailspring folder (e.g., Snoozed) is created.

Adding autorelease() immediately after construction ensures the object
will be properly released when the AutoreleasePool at the start of
syncFoldersAndLabels() is drained. This matches the pattern used
elsewhere in the codebase (e.g., TaskProcessor.cpp, MailProcessor.cpp).