### PR TITLE
Fix thread reference indexing to use first 1 + last N-1 pattern

### DIFF
--- a/MailSync/MailProcessor.cpp
+++ b/MailSync/MailProcessor.cpp
@@ -504,14 +504,28 @@ void MailProcessor::upsertThreadReferences(string threadId, string accountId, st
     query.exec();
     query.reset();
 
-    // todo: technically, we should look at the first reference (Start of thread)
-    // and then the last N, where N is some number we give a shit about, but we've
-    // rarely seen more than 100 items.
-    for (int i = 0; i < min(100, (int)references->count()); i ++) {
+    // Index the first reference (thread root) and last N-1 references (most recent).
+    // This ensures thread continuity through the root while keeping recent messages connected.
+    // If count <= MAX_REFS, all references are indexed.
+    const int MAX_REFS = 100;
+    int count = (int)references->count();
+    int lastNCount = min(MAX_REFS - 1, count - 1);
+    int lastNStart = count - lastNCount;
+
+    // Index first reference (thread root)
+    if (count > 0) {
+        String * firstRef = (String*)references->objectAtIndex(0);
+        query.bind(3, firstRef->UTF8Characters());
+        query.exec();
+        query.reset(); // does not clear bindings 1 and 2! https://sqlite.org/c3ref/reset.html
+    }
+
+    // Index last N-1 references (most recent), skipping index 0 to avoid duplicate
+    for (int i = max(1, lastNStart); i < count; i++) {
         String * address = (String*)references->objectAtIndex(i);
         query.bind(3, address->UTF8Characters());
         query.exec();
-        query.reset(); // does not clear bindings 1 and 2! https://sqlite.org/c3ref/reset.html
+        query.reset();
     }
 }
 


### PR DESCRIPTION
Previously, only the first 100 references were indexed for thread
threading, which could cause threading failures for messages with
many references (the most recent replies would be missed).

Now the algorithm indexes:
- The first reference (thread root) to maintain thread continuity
- The last 99 references (most recent) for proper threading of replies

This ensures that even for very long email threads, both the
original thread starter and recent messages can be properly
associated with the correct thread.