### PR TITLE
Fix null pointer dereference in retrievedMessageBody

### DIFF
--- a/MailSync/MailProcessor.cpp
+++ b/MailSync/MailProcessor.cpp
@@ -246,8 +246,13 @@ void MailProcessor::retrievedMessageBody(Message * message, MessageParser * pars
     // times to retrieve attachments, relatedAttachments, message HTML separately. The code seems to build
     // and discard things you don't ask for.
     String * html = parser->htmlRenderingAndAttachments(htmlCallback, partAttachments, htmlInlineAttachments);
+    if (html == NULL) {
+        logger->warn("Failed to render message body for message {}: parser returned null", message->id());
+        MC_SAFE_RELEASE(htmlCallback);
+        return;
+    }
     String * text = html;
-    
+
     if (html->hasPrefix(MCSTR("PLAINTEXT:"))) {
         text = html->substringFromIndex(10);
         bodyRepresentation = text->UTF8Characters();


### PR DESCRIPTION
The htmlRenderingAndAttachments() method can return NULL when:
- The message parser has no main part
- Data retrieval fails during rendering
- Various rendering failures for multipart messages

Without this check, calling html->hasPrefix() on a null pointer
causes a crash when parsing certain malformed or unusual messages.

Add null check with proper cleanup (MC_SAFE_RELEASE for the callback)
and early return with a warning log to aid debugging.