### PR TITLE
Fix prepared statement cache to clear bindings after error

### DIFF
--- a/MailSync/MailStore.cpp
+++ b/MailSync/MailStore.cpp
@@ -359,6 +359,7 @@ void MailStore::save(MailModel * model) {
         }
         auto query = _saveUpdateQueries[tableName];
         query->reset();
+        query->clearBindings();
         model->bindToQuery(query.get());
         query->exec();
         
@@ -379,6 +380,7 @@ void MailStore::save(MailModel * model) {
         
         auto query = _saveInsertQueries[tableName];
         query->reset();
+        query->clearBindings();
         model->bindToQuery(query.get());
         query->exec();
     }
@@ -423,6 +425,7 @@ void MailStore::remove(MailModel * model) {
     }
     auto query = _removeQueries[tableName];
     query->reset();
+    query->clearBindings();
     query->bind(1, model->id());
     query->exec();
 
@@ -488,6 +491,7 @@ vector<Metadata> MailStore::findAndDeleteDetatchedPluginMetadata(string accountI
     vector<Metadata> results;
     auto st = _saveInsertQueries["metadata"];
     st->reset();
+    st->clearBindings();
     st->bind(1, objectId);
     st->bind(2, accountId);
     while (st->executeStep()) {


### PR DESCRIPTION
Add clearBindings() after reset() when reusing cached prepared
statements. According to SQLiteCpp documentation, reset() does NOT
clear parameter bindings - only clearBindings() does this. If exec()
throws an exception and the statement is reused, stale bindings from
the failed attempt could persist and potentially cause issues if
bindToQuery() partially fails on retry.

This is a defensive fix following SQLiteCpp's documented best practice
for statement reuse.

Locations fixed:
- save() UPDATE query (line 362)
- save() INSERT query (line 383)
- remove() DELETE query (line 428)
- findAndDeleteDetatchedPluginMetadata() SELECT query (line 494)