### PR TITLE
Consolidate duplicate isGmail checks in folder/label handling

### DIFF
--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -1171,19 +1171,13 @@ void TaskProcessor::performRemoteSyncbackCategory(Task * task) {
     shared_ptr<Folder> localModel = nullptr;
     
     if (existingPath != "") {
-        if (isGmail) {
-            localModel = store->find<Label>(Query().equal("accountId", accountId).equal("id", MailUtils::idForFolder(accountId, existingPath)));
-        } else {
-            localModel = store->find<Folder>(Query().equal("accountId", accountId).equal("id", MailUtils::idForFolder(accountId, existingPath)));
-        }
+        auto query = Query().equal("accountId", accountId).equal("id", MailUtils::idForFolder(accountId, existingPath));
+        localModel = isGmail ? store->find<Label>(query) : store->find<Folder>(query);
     }
 
     if (!localModel) {
-        if (isGmail) {
-            localModel = make_shared<Label>(MailUtils::idForFolder(accountId, path), accountId, 0);
-        } else {
-            localModel = make_shared<Folder>(MailUtils::idForFolder(accountId, path), accountId, 0);
-        }
+        string id = MailUtils::idForFolder(accountId, path);
+        localModel = isGmail ? make_shared<Label>(id, accountId, 0) : make_shared<Folder>(id, accountId, 0);
     }
 
     localModel->setPath(path);


### PR DESCRIPTION
Refactored the Label/Folder selection pattern in performRemoteSyncbackCategory
to use ternary operators instead of nested if-else blocks. This eliminates
duplicate isGmail checks while maintaining the same functionality:

- Extract query construction to a reusable variable
- Extract folder ID computation to a named variable
- Use ternary operators for type selection at both find and create sites

The polymorphic behavior is preserved since Label inherits from Folder,
allowing shared_ptr<Label> to implicitly convert to shared_ptr<Folder>.