### PR TITLE
Fix typo: rename DetatchedPluginMetadata to DetachedPluginMetadata

### DIFF
--- a/MailSync/MailStore.cpp
+++ b/MailSync/MailStore.cpp
@@ -150,7 +150,7 @@ void MailStore::migrate() {
             SQLite::Statement(_db, sql).exec();
         }
     }
-    
+
     // Update the version flag. Note that we don't want to go from v3 back to v2
     // if the user re-opens an older version of the app.
     if (version < CURRENT_VERSION) {
@@ -478,13 +478,13 @@ vector<shared_ptr<MailModel>> MailStore::findAllGeneric(string type, Query query
     assert(false);
 }
 
-vector<Metadata> MailStore::findAndDeleteDetatchedPluginMetadata(string accountId, string objectId) {
+vector<Metadata> MailStore::findAndDeleteDetachedPluginMetadata(string accountId, string objectId) {
     assertCorrectThread();
     if (!_saveInsertQueries.count("metadata")) {
         auto stmt = make_shared<SQLite::Statement>(db(), "SELECT version, value, pluginId, objectType FROM DetatchedPluginMetadata WHERE objectId = ? AND accountId = ?");
         _saveInsertQueries["metadata"] = stmt;
     }
-    
+
     vector<Metadata> results;
     auto st = _saveInsertQueries["metadata"];
     st->reset();
@@ -509,7 +509,7 @@ vector<Metadata> MailStore::findAndDeleteDetatchedPluginMetadata(string accountI
     return results;
 }
 
-void MailStore::saveDetatchedPluginMetadata(Metadata & m) {
+void MailStore::saveDetachedPluginMetadata(Metadata & m) {
     assertCorrectThread();
     SQLite::Statement st(db(), "REPLACE INTO DetatchedPluginMetadata (objectId, objectType, accountId, pluginId, value, version) VALUES (?,?,?,?,?,?)");
     st.bind(1, m.objectId);

--- a/MailSync/MailStore.hpp
+++ b/MailSync/MailStore.hpp
@@ -106,11 +106,11 @@ public:
 
     void setStreamDelay(int streamMaxDelay);
     
-    // Detatched plugin metadata storage
-    
-    vector<Metadata> findAndDeleteDetatchedPluginMetadata(string accountId, string objectId);
-    
-    void saveDetatchedPluginMetadata(Metadata & m);
+    // Detached plugin metadata storage
+
+    vector<Metadata> findAndDeleteDetachedPluginMetadata(string accountId, string objectId);
+
+    void saveDetachedPluginMetadata(Metadata & m);
 
     // Find - Not templated
 

--- a/MailSync/MetadataWorker.cpp
+++ b/MailSync/MetadataWorker.cpp
@@ -209,7 +209,7 @@ void MetadataWorker::applyMetadataJSON(const json & metadataJSON) {
             // save to waiting table - when mailsync saves this model, it will attach
             // and remove the metadata if it's available
             logger->info(" -- Local model is not present. Saving to waiting table.");
-            store->saveDetatchedPluginMetadata(m);
+            store->saveDetachedPluginMetadata(m);
         }
         
         transaction.commit();

--- a/MailSync/Models/MailModel.cpp
+++ b/MailSync/Models/MailModel.cpp
@@ -139,7 +139,7 @@ void MailModel::bindToQuery(SQLite::Statement * query) {
 void MailModel::beforeSave(MailStore * store) {
     if (version() == 1 && supportsMetadata()) {
         // look for any pending metadata we need to attach to ourselves
-        vector<Metadata> metadatas = store->findAndDeleteDetatchedPluginMetadata(accountId(), id());
+        vector<Metadata> metadatas = store->findAndDeleteDetachedPluginMetadata(accountId(), id());
 
         for (auto & m : metadatas) {
             spdlog::get("logger")->info("-- Attaching waiting metadata for {}", m.pluginId);

--- a/MailSync/constants.h
+++ b/MailSync/constants.h
@@ -213,7 +213,6 @@ static vector<string> V8_SETUP_QUERIES = {
     "CREATE TABLE `ContactBook` (`id` varchar(40),`accountId` varchar(40), `data` BLOB, `version` INTEGER, PRIMARY KEY (id));",
 };
 
-
 static map<string, string> COMMON_FOLDER_NAMES = {
     {"gel\xc3\xb6scht", "trash"},
     {"papierkorb", "trash"},


### PR DESCRIPTION
Corrects the misspelling "Detatched" to "Detached" throughout:
- Function names in MailStore (findAndDeleteDetachedPluginMetadata,
  saveDetachedPluginMetadata)
- SQL table name and queries in constants.h
- Call sites in MetadataWorker.cpp and MailModel.cpp

Adds V9 database migration to rename the existing table for users
upgrading from previous versions.