### PR TITLE
Add null check for data from fetchMessageByUID before parsing

### DIFF
--- a/MailSync/SyncWorker.cpp
+++ b/MailSync/SyncWorker.cpp
@@ -1049,6 +1049,11 @@ void SyncWorker::syncMessageBody(Message * message) {
 
         throw SyncException(err, "syncMessageBody - fetchMessageByUID");
     }
+    if (data == nullptr) {
+        logger->error("fetchMessageByUID returned null data for message \"{}\" ({} UID {})",
+                      message->subject(), folderPath, message->remoteUID());
+        return;
+    }
     MessageParser * messageParser = MessageParser::messageParserWithData(data);
     processor->retrievedMessageBody(message, messageParser);
 }

--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -1708,6 +1708,10 @@ void TaskProcessor::performRemoteGetMessageRFC2822(Task * task) {
         logger->error("Unable to fetch rfc2822 for message (UID {}). Error {}", msg->remoteUID(), ErrorCodeToTypeMap[err]);
         throw SyncException(err, "performRemoteGetMessageRFC2822");
     }
+    if (data == nullptr) {
+        logger->error("fetchMessageByUID returned null data for message (UID {})", msg->remoteUID());
+        throw SyncException(ErrorFetch, "performRemoteGetMessageRFC2822 - null data");
+    }
 #ifdef _MSC_VER
     wstring_convert<codecvt_utf8<wchar_t>, wchar_t> convert;
     data->writeToFile(AS_WIDE_MCSTR(convert.from_bytes(filepath)));


### PR DESCRIPTION
The mailcore2 fetchMessageByUID function can return null data even when
no error code is set. This was confirmed by examining mailcore2's own
MCIMAPFetchParsedContentOperation.cpp which checks `if (data)` before
creating a MessageParser. Passing null to MessageParser::messageParserWithData
would crash when the constructor tries to access data->bytes().

Fixes are applied to:
- SyncWorker::syncMessageBody - returns early with error log
- TaskProcessor::performRemoteGetMessageRFC2822 - throws SyncException