### PR TITLE
Fix CalDAV HTTP protocol issues

### DIFF
--- a/MailSync/DavXML.cpp
+++ b/MailSync/DavXML.cpp
@@ -17,6 +17,13 @@ using namespace std;
 DavXML::DavXML(string xml, string url):
     xpathContext(nullptr)
 {
+    // HTTP Protocol Quirk: Content-Type Header Mismatches
+    // Many CalDAV servers (notably iCloud and Open-Xchange) return valid XML but with
+    // incorrect Content-Type headers like "text/plain" instead of "text/xml" or
+    // "application/xml". The Python caldav library handles this by parsing XML regardless
+    // of Content-Type, and we do the same - we simply attempt to parse whatever the server
+    // returns without checking Content-Type first. This pragmatic approach ensures
+    // compatibility with non-compliant servers.
     doc = xmlReadMemory(xml.c_str(), (int)xml.size(), url.c_str(), "utf-8", 0);
     if (doc == nullptr) {
         throw new SyncException("Unable to parse CalDav XML", xml, false);


### PR DESCRIPTION
Add comments documenting how the implementation handles (or bypasses) common CalDAV server quirks identified in the Python caldav library:
- Content-Type mismatches (iCloud, Open-Xchange): handled by parsing XML regardless of Content-Type header
- WWW-Authenticate parsing issues: bypassed via pre-authentication
- Header case sensitivity: handled via case-insensitive extraction
- HTTP/2 multiplexing failures (Baikal): documented as potential issue