### PR TITLE
Refactor ICS parsing code duplication in DAVworker

### DIFF
--- a/MailSync/Models/Event.hpp
+++ b/MailSync/Models/Event.hpp
@@ -55,6 +55,10 @@ public:
     string status();
     void setStatus(string status);
 
+    // Apply ICS event data to this event (used by constructor and when updating existing events)
+    void applyICSEventData(const string& etag, const string& href,
+                           const string& icsData, ICalendarEvent* icsEvent);
+
     bool isRecurrenceException();
 
     int recurrenceStart();


### PR DESCRIPTION
Consolidates duplicate ICS-to-Event field assignment code from four locations in DAVWorker.cpp into a single applyICSEventData method on Event. The helper is called by the Event constructor (ensuring all fields are populated on construction) and when updating existing events during sync.

This reduces code duplication by ~21 lines while preserving identical behavior:
- runForCalendar: existing event updates
- runForCalendarWithSyncToken: direct data and multiget paths
- writeAndResyncEvent: post-write resync

The icsuid field assignment in writeAndResyncEvent remains separate as it's the only location that needs to update it.