### PR TITLE
Fix Data Race on idleShouldReloop Flag

### DIFF
--- a/MailSync/SyncWorker.hpp
+++ b/MailSync/SyncWorker.hpp
@@ -14,6 +14,7 @@
 
 #include <stdio.h>
 
+#include <atomic>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -35,7 +36,7 @@ class SyncWorker {
     shared_ptr<spdlog::logger> logger;
 
     int unlinkPhase;
-    bool idleShouldReloop;
+    std::atomic<bool> idleShouldReloop{false};
     int iterationsSinceLaunch;
     vector<string> idleFetchBodyIDs;
     std::mutex idleMtx;


### PR DESCRIPTION
The idleShouldReloop flag was accessed without synchronization from multiple threads: idleInterrupt() (called from main thread) wrote with mutex held, but idleCycleIteration() (foreground worker thread) read and wrote without any lock.

Change idleShouldReloop from bool to std::atomic<bool> to ensure thread-safe access. Also add explicit initialization to false.