### PR TITLE
Fix Missing RAII Transaction Wrapper

### DIFF
--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -894,13 +894,13 @@ void TaskProcessor::performLocalDestroyContact(Task * task) {
     }
 
     {
-        store->beginTransaction();
+        MailStoreTransaction transaction{store, "performLocalDestroyContact"};
         auto deleted = store->findLargeSet<Contact>("id", contactIds);
         for (auto & c : deleted) {
             c->setHidden(true);
             store->save(c.get());
         }
-        store->commitTransaction();
+        transaction.commit();
     }
 }
 


### PR DESCRIPTION
Replace manual beginTransaction()/commitTransaction() calls with MailStoreTransaction RAII wrapper to ensure automatic rollback if an exception is thrown during the operation.