### PR TITLE
Fix bgWorkerShouldMarkAll Data Race

### DIFF
--- a/MailSync/main.cpp
+++ b/MailSync/main.cpp
@@ -9,6 +9,7 @@
 //  in 'LICENSE.md', which is part of the Mailspring-Sync package.
 //
 
+#include <atomic>
 #include <iostream>
 #include <string>
 #include <time.h>
@@ -59,7 +60,7 @@ shared_ptr<GoogleContactsWorker> contactsWorker = nullptr;
 shared_ptr<MetadataWorker> metadataWorker = nullptr;
 shared_ptr<MetadataExpirationWorker> metadataExpirationWorker = nullptr;
 
-bool bgWorkerShouldMarkAll = true;
+std::atomic<bool> bgWorkerShouldMarkAll{true};
 
 std::thread * fgThread = nullptr;
 std::thread * bgThread = nullptr;


### PR DESCRIPTION
Change bgWorkerShouldMarkAll from bool to std::atomic<bool> to fix a data race between the main thread (which writes to the variable in the wake-workers handler) and the background thread (which reads and writes to it in runBackgroundSyncWorker).

Without atomic synchronization, concurrent access to this variable was undefined behavior per the C++ standard.