### PR TITLE
Fix TOCTOU Race in Task Wake Scheduling

### DIFF
--- a/MailSync/main.cpp
+++ b/MailSync/main.cpp
@@ -438,7 +438,8 @@ void runListenOnMainThread(shared_ptr<Account> account) {
                 // syncback. This also mitigates any potential remote loads+saves that aren't inside transactions
                 // and could overwrite local changes.
                 static atomic<bool> queuedForegroundWake { false };
-                if (!queuedForegroundWake) {
+                bool expected = false;
+                if (queuedForegroundWake.compare_exchange_strong(expected, true)) {
                     std::thread([]() {
                         std::this_thread::sleep_for(chrono::milliseconds(300));
                         if (fgWorker) {
@@ -446,7 +447,6 @@ void runListenOnMainThread(shared_ptr<Account> account) {
                         }
                         queuedForegroundWake = false;
                     }).detach();
-                    queuedForegroundWake = true;
                 }
             }
             

--- a/MailSync/main.cpp
+++ b/MailSync/main.cpp
@@ -484,14 +484,14 @@ void runListenOnMainThread(shared_ptr<Account> account) {
 
             if (type == "sync-calendar") {
                 static atomic<bool> runningCalendarSync { false };
-                if (!runningCalendarSync) {
-                    std::thread([&]() {
+                bool expected = false;
+                if (runningCalendarSync.compare_exchange_strong(expected, true)) {
+                    std::thread([account]() {
                         SetThreadName("calendar");
                         auto worker = DAVWorker(account);
                         worker.run();
                         runningCalendarSync = false;
                     }).detach();
-                    runningCalendarSync = true;
                 }
             }
 


### PR DESCRIPTION
Use compare_exchange_strong for atomic check-and-set when scheduling foreground wake interrupts. This eliminates the race condition between checking !queuedForegroundWake and setting it to true, where two tasks arriving in quick succession could both pass the check and spawn threads.