### PR TITLE
Fix Graceful Cancellation of Streaming Connection

### DIFF
--- a/MailSync/MetadataWorker.hpp
+++ b/MailSync/MetadataWorker.hpp
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 
+#include <atomic>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -30,14 +31,17 @@ class MetadataWorker {
     MailStore * store;
     shared_ptr<spdlog::logger> logger;
     shared_ptr<Account> account;
-    
+
     string deltasBuffer;
     string deltasCursor;
     int backoffStep;
+    std::atomic<bool> _cancelled{false};
 
 public:
+    void cancel();
+    bool isCancelled() const;
     MetadataWorker(shared_ptr<Account> account);
-    
+
     void run();
 
     bool fetchMetadata(int page);

--- a/MailSync/main.cpp
+++ b/MailSync/main.cpp
@@ -419,7 +419,11 @@ void runListenOnMainThread(shared_ptr<Account> account) {
             }
             if (time(0) - lostCINAt > 30) {
                 // note: don't run termination / stack trace handlers,
-                // just exit.
+                // just exit. Cancel the metadata worker to abort its
+                // streaming connection promptly.
+                if (metadataWorker) {
+                    metadataWorker->cancel();
+                }
                 std::exit(141);
             }
 			std::this_thread::sleep_for(std::chrono::microseconds(1000));


### PR DESCRIPTION
The fetchDeltasBlocking() function previously used a blocking curl_easy_perform() with no way to interrupt it during shutdown. A buggy server could keep the connection alive indefinitely.

This fix uses CURLOPT_XFERINFOFUNCTION to register a progress callback that checks an atomic cancellation flag. When cancelled, the callback returns non-zero to abort the transfer, and curl returns CURLE_ABORTED_BY_CALLBACK.

Changes:
- Add std::atomic<bool> _cancelled flag and cancel()/isCancelled() API
- Add _onProgress callback that returns 1 when cancelled
- Configure curl with CURLOPT_NOPROGRESS=0 and the progress callback
- Update run() loop to check cancellation and exit cleanly
- Handle CURLE_ABORTED_BY_CALLBACK without throwing errors