### PR TITLE
Fix Memory Leaks in curl Header Lists

### DIFF
--- a/MailSync/MetadataWorker.cpp
+++ b/MailSync/MetadataWorker.cpp
@@ -117,7 +117,10 @@ void MetadataWorker::fetchDeltasBlocking() {
     platform = "darwin";
 #endif
     const char * a = account->IMAPHost().c_str();
-    string aEscaped = curl_escape(a, (int)strlen(a));
+    char * aEscapedPtr = curl_escape(a, (int)strlen(a));
+    string aEscaped = aEscapedPtr;
+    curl_free(aEscapedPtr);
+
     CURL * curl_handle = CreateIdentityRequest("/deltas/" + account->id() + "/streaming?p=" + platform + "&ih=" + aEscaped + "&cursor=" + deltasCursor);
     curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, _onDeltaData);
     curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)this);
@@ -141,7 +144,7 @@ void MetadataWorker::fetchDeltasBlocking() {
     }
 
     ValidateRequestResp(res, curl_handle, "");
-    curl_easy_cleanup(curl_handle);
+    CleanupCurlRequest(curl_handle);
 }
 
 void MetadataWorker::setDeltaCursor(string cursor) {

--- a/MailSync/NetworkRequestUtils.hpp
+++ b/MailSync/NetworkRequestUtils.hpp
@@ -23,6 +23,9 @@ using namespace std;
 
 size_t _onAppendToString(void *contents, size_t length, size_t nmemb, void *userp);
 
+// Helper to cleanup curl handle and associated header list stored in CURLOPT_PRIVATE
+void CleanupCurlRequest(CURL * curl_handle);
+
 CURL * CreateJSONRequest(string url, string method = "GET", string authorization = "", const char * payloadChars = nullptr);
 CURL * CreateCalDavRequest(string url, string method = "GET", const char * payloadChars = nullptr);
 


### PR DESCRIPTION
- Add CurlRequestData struct and CleanupCurlRequest() helper to properly free curl_slist headers stored via CURLOPT_PRIVATE
- Fix MakeOAuthRefreshRequest: free curl_easy_escape() results with curl_free()
- Fix CreateJSONRequest: store headers in CurlRequestData for proper cleanup
- Update curl_easy_cleanup() calls to use CleanupCurlRequest() in PerformJSONRequest and ValidateRequestResp
- Fix MetadataWorker::fetchDeltasBlocking: free curl_escape() result and use CleanupCurlRequest()

Addresses memory leaks where curl_slist headers were never freed (every network request leaked memory) and curl_escape/curl_easy_escape returned malloc'd memory that was never freed.