### PR TITLE
Fix missing libsasl2 dependency on Fedora

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,7 +59,7 @@ elif [[ "$OSTYPE" == "linux-gnu" ]]; then
   # (We set SASL_PATH below so it finds these.)
   cp /usr/lib/x86_64-linux-gnu/sasl2/* "$APP_ROOT_DIR"
 
-  printf "#!/bin/bash\nset -e\nset -o pipefail\nSCRIPTPATH=\"\$( cd \"\$(dirname \"\$0\")\" >/dev/null 2>&1 ; pwd -P )\"\nSASL_PATH=\"\$SCRIPTPATH\" LD_LIBRARY_PATH=\"\$SCRIPTPATH;\$LD_LIBRARY_PATH\" \"\$SCRIPTPATH/mailsync.bin\" \"\$@\"" > "$APP_ROOT_DIR/mailsync"
+  printf "#!/bin/bash\nset -e\nset -o pipefail\nSCRIPTPATH=\"\$( cd \"\$(dirname \"\$0\")\" >/dev/null 2>&1 ; pwd -P )\"\nSASL_PATH=\"\$SCRIPTPATH\" LD_LIBRARY_PATH=\"\$SCRIPTPATH:\$LD_LIBRARY_PATH\" \"\$SCRIPTPATH/mailsync.bin\" \"\$@\"" > "$APP_ROOT_DIR/mailsync"
   chmod +x "$APP_ROOT_DIR/mailsync"
 
   # Zip this stuff up so we can push it to S3 as a single artifacts


### PR DESCRIPTION
The wrapper script was using a semicolon as the path separator for LD_LIBRARY_PATH, but Linux requires colons. This prevented the bundled libsasl2.so.2 from being found by the dynamic linker, causing the binary to fail on Fedora 40/41 (which only has libsasl2.so.3 installed).

With this fix, the bundled libsasl2.so.2 from Ubuntu will be correctly found via LD_LIBRARY_PATH, making the binary work across distributions.