### PR TITLE
libetpan: Add TLS Server Name Indication (SNI) support

### DIFF
--- a/Vendor/libetpan/src/data-types/mailstream_ssl.c
+++ b/Vendor/libetpan/src/data-types/mailstream_ssl.c
@@ -433,7 +433,7 @@ static int mailstream_openssl_client_cert_cb(SSL *ssl, X509 **x509, EVP_PKEY **p
 }
 
 static struct mailstream_ssl_data * ssl_data_new_full(int fd, time_t timeout,
-	SSL_METHOD * method, void (* callback)(struct mailstream_ssl_context * ssl_context, void * cb_data),
+	const SSL_METHOD * method, void (* callback)(struct mailstream_ssl_context * ssl_context, void * cb_data),
 	void * cb_data)
 {
   struct mailstream_ssl_data * ssl_data;
@@ -460,14 +460,13 @@ static struct mailstream_ssl_data * ssl_data_new_full(int fd, time_t timeout,
   SSL_CTX_set_app_data(tmp_ctx, ssl_context);
   SSL_CTX_set_client_cert_cb(tmp_ctx, mailstream_openssl_client_cert_cb);
   ssl_conn = (SSL *) SSL_new(tmp_ctx);
-  
-#ifdef SSL_MODE_RELEASE_BUFFERS
+  if (ssl_conn == NULL)
+    goto free_ctx;
+
+#if SSL_MODE_RELEASE_BUFFERS
   mode = SSL_get_mode(ssl_conn);
   SSL_set_mode(ssl_conn, mode | SSL_MODE_RELEASE_BUFFERS);
 #endif
-  
-  if (ssl_conn == NULL)
-    goto free_ctx;
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
   if (ssl_context != NULL && ssl_context->server_name != NULL) {

--- a/Vendor/libetpan/src/data-types/mailstream_ssl.c
+++ b/Vendor/libetpan/src/data-types/mailstream_ssl.c
@@ -113,6 +113,9 @@ struct mailstream_ssl_context
   SSL_CTX * openssl_ssl_ctx;
   X509* client_x509;
   EVP_PKEY *client_pkey;
+# if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
+  char * server_name;
+# endif /* (OPENSSL_VERSION_NUMBER >= 0x10000000L) */
 #else
   gnutls_session session;
   gnutls_x509_crt client_x509;
@@ -465,7 +468,15 @@ static struct mailstream_ssl_data * ssl_data_new_full(int fd, time_t timeout,
   
   if (ssl_conn == NULL)
     goto free_ctx;
-  
+
+#if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
+  if (ssl_context != NULL && ssl_context->server_name != NULL) {
+    SSL_set_tlsext_host_name(ssl_conn, ssl_context->server_name);
+    free(ssl_context->server_name);
+    ssl_context->server_name = NULL;
+  }
+#endif /* (OPENSSL_VERSION_NUMBER >= 0x10000000L) */
+
   if (SSL_set_fd(ssl_conn, fd) == 0)
     goto free_ssl_conn;
   
@@ -1363,6 +1374,47 @@ int mailstream_ssl_set_server_certicate(struct mailstream_ssl_context * ssl_cont
 #endif /* USE_SSL */
 }
 
+LIBETPAN_EXPORT
+int mailstream_ssl_set_server_name(struct mailstream_ssl_context * ssl_context,
+    char * hostname)
+{
+  int r = -1;
+
+#ifdef USE_SSL
+# ifdef USE_GNUTLS
+  if (hostname != NULL) {
+    r = gnutls_server_name_set(ssl_context->session, GNUTLS_NAME_DNS, hostname, strlen(hostname));
+  }
+  else {
+    r = gnutls_server_name_set(ssl_context->session, GNUTLS_NAME_DNS, "", 0U);
+  }
+# else /* !USE_GNUTLS */
+#  if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
+  if (hostname != NULL) {
+    /* Unfortunately we can't set this in the openssl session yet since it
+     * hasn't been created yet; we only have the openssl context at this point.
+     * We will set it in the openssl session when we create it, soon after the
+     * client callback that we expect to be calling us (since it is the way the
+     * client gets our mailstream_ssl_context) returns (see
+     * ssl_data_new_full()) but we cannot rely on the client persisting it. We
+     * must therefore take a temporary copy here, which we free once we've set
+     * it in the openssl session. */
+    ssl_context->server_name = strdup(hostname);
+  }
+  else {
+    if (ssl_context->server_name != NULL) {
+      free(ssl_context->server_name);
+    }
+    ssl_context->server_name = NULL;
+  }
+  r = 0;
+#  endif /* (OPENSSL_VERSION_NUMBER >= 0x10000000L) */
+# endif /* !USE_GNUTLS */
+#endif /* USE_SSL */
+
+  return r;
+}
+
 #ifdef USE_SSL
 #ifndef USE_GNUTLS
 static struct mailstream_ssl_context * mailstream_ssl_context_new(SSL_CTX * open_ssl_ctx, int fd)
@@ -1376,15 +1428,24 @@ static struct mailstream_ssl_context * mailstream_ssl_context_new(SSL_CTX * open
   ssl_ctx->openssl_ssl_ctx = open_ssl_ctx;
   ssl_ctx->client_x509 = NULL;
   ssl_ctx->client_pkey = NULL;
+#if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
+  ssl_ctx->server_name = NULL;
+#endif /* (OPENSSL_VERSION_NUMBER >= 0x10000000L) */
   ssl_ctx->fd = fd;
-  
+
   return ssl_ctx;
 }
 
 static void mailstream_ssl_context_free(struct mailstream_ssl_context * ssl_ctx)
 {
-  if (ssl_ctx)
+  if (ssl_ctx != NULL) {
+#if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
+    if (ssl_ctx->server_name != NULL) {
+      free(ssl_ctx->server_name);
+    }
+#endif /* (OPENSSL_VERSION_NUMBER >= 0x10000000L) */
     free(ssl_ctx);
+  }
 }
 #else
 static struct mailstream_ssl_context * mailstream_ssl_context_new(gnutls_session session, int fd)

--- a/Vendor/libetpan/src/data-types/mailstream_ssl.h
+++ b/Vendor/libetpan/src/data-types/mailstream_ssl.h
@@ -120,8 +120,12 @@ int mailstream_ssl_set_client_private_key_data(struct mailstream_ssl_context * s
     unsigned char *pkey_der, size_t len);
 
 LIBETPAN_EXPORT
-int mailstream_ssl_set_server_certicate(struct mailstream_ssl_context * ssl_context, 
+int mailstream_ssl_set_server_certicate(struct mailstream_ssl_context * ssl_context,
     char * CAfile, char * CApath);
+
+LIBETPAN_EXPORT
+int mailstream_ssl_set_server_name(struct mailstream_ssl_context * ssl_context,
+    char * hostname);
 
 LIBETPAN_EXPORT
 void * mailstream_ssl_get_openssl_ssl_ctx(struct mailstream_ssl_context * ssl_context);

--- a/Vendor/mailcore2/Externals/include/libetpan/mailstream_ssl.h
+++ b/Vendor/mailcore2/Externals/include/libetpan/mailstream_ssl.h
@@ -120,8 +120,12 @@ int mailstream_ssl_set_client_private_key_data(struct mailstream_ssl_context * s
     unsigned char *pkey_der, size_t len);
 
 LIBETPAN_EXPORT
-int mailstream_ssl_set_server_certicate(struct mailstream_ssl_context * ssl_context, 
+int mailstream_ssl_set_server_certicate(struct mailstream_ssl_context * ssl_context,
     char * CAfile, char * CApath);
+
+LIBETPAN_EXPORT
+int mailstream_ssl_set_server_name(struct mailstream_ssl_context * ssl_context,
+    char * hostname);
 
 LIBETPAN_EXPORT
 void * mailstream_ssl_get_openssl_ssl_ctx(struct mailstream_ssl_context * ssl_context);

--- a/Vendor/mailcore2/src/core/imap/MCIMAPSession.cpp
+++ b/Vendor/mailcore2/src/core/imap/MCIMAPSession.cpp
@@ -5,6 +5,11 @@
 #include <libetpan/libetpan.h>
 #include <string.h>
 #include <stdlib.h>
+#ifdef _MSC_VER
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#endif
 
 #include "MCDefines.h"
 #include "MCIMAPSearchExpression.h"
@@ -611,11 +616,27 @@ static void logger(mailimap * imap, int log_type, const char * buffer, size_t si
     session->unlockConnectionLogger();
 }
 
+static bool isIPAddress(const char * hostname)
+{
+    // Check if hostname is an IPv4 or IPv6 address
+    // SNI should only be used for hostnames, not IP addresses
+    struct in_addr ipv4addr;
+    struct in6_addr ipv6addr;
+    if (inet_pton(AF_INET, hostname, &ipv4addr) == 1) {
+        return true;
+    }
+    if (inet_pton(AF_INET6, hostname, &ipv6addr) == 1) {
+        return true;
+    }
+    return false;
+}
+
 static void ssl_callback(struct mailstream_ssl_context * ssl_context, void * data)
 {
     // Set the Server Name Indication (SNI) for TLS connections
+    // SNI only makes sense for hostnames, not IP addresses
     const char * hostname = (const char *) data;
-    if (hostname != NULL) {
+    if (hostname != NULL && !isIPAddress(hostname)) {
         mailstream_ssl_set_server_name(ssl_context, (char *) hostname);
     }
 }

--- a/Vendor/mailcore2/src/core/pop/MCPOPSession.cpp
+++ b/Vendor/mailcore2/src/core/pop/MCPOPSession.cpp
@@ -4,6 +4,11 @@
 
 #include <string.h>
 #include <libetpan/libetpan.h>
+#ifdef _MSC_VER
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#endif
 
 #include "MCPOPMessageInfo.h"
 #include "MCPOPProgressCallback.h"
@@ -177,11 +182,27 @@ static void logger(mailpop3 * pop3, int log_type, const char * buffer, size_t si
     session->unlockConnectionLogger();
 }
 
+static bool isIPAddress(const char * hostname)
+{
+    // Check if hostname is an IPv4 or IPv6 address
+    // SNI should only be used for hostnames, not IP addresses
+    struct in_addr ipv4addr;
+    struct in6_addr ipv6addr;
+    if (inet_pton(AF_INET, hostname, &ipv4addr) == 1) {
+        return true;
+    }
+    if (inet_pton(AF_INET6, hostname, &ipv6addr) == 1) {
+        return true;
+    }
+    return false;
+}
+
 static void ssl_callback(struct mailstream_ssl_context * ssl_context, void * data)
 {
     // Set the Server Name Indication (SNI) for TLS connections
+    // SNI only makes sense for hostnames, not IP addresses
     const char * hostname = (const char *) data;
-    if (hostname != NULL) {
+    if (hostname != NULL && !isIPAddress(hostname)) {
         mailstream_ssl_set_server_name(ssl_context, (char *) hostname);
     }
 }

--- a/Vendor/mailcore2/src/core/smtp/MCSMTPSession.cpp
+++ b/Vendor/mailcore2/src/core/smtp/MCSMTPSession.cpp
@@ -4,6 +4,11 @@
 
 #include <string.h>
 #include <libetpan/libetpan.h>
+#ifdef _MSC_VER
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#endif
 
 #include "MCAddress.h"
 #include "MCMessageBuilder.h"
@@ -251,11 +256,27 @@ static void logger(mailsmtp * smtp, int log_type, const char * buffer, size_t si
     session->unlockConnectionLogger();
 }
 
+static bool isIPAddress(const char * hostname)
+{
+    // Check if hostname is an IPv4 or IPv6 address
+    // SNI should only be used for hostnames, not IP addresses
+    struct in_addr ipv4addr;
+    struct in6_addr ipv6addr;
+    if (inet_pton(AF_INET, hostname, &ipv4addr) == 1) {
+        return true;
+    }
+    if (inet_pton(AF_INET6, hostname, &ipv6addr) == 1) {
+        return true;
+    }
+    return false;
+}
+
 static void ssl_callback(struct mailstream_ssl_context * ssl_context, void * data)
 {
     // Set the Server Name Indication (SNI) for TLS connections
+    // SNI only makes sense for hostnames, not IP addresses
     const char * hostname = (const char *) data;
-    if (hostname != NULL) {
+    if (hostname != NULL && !isIPAddress(hostname)) {
         mailstream_ssl_set_server_name(ssl_context, (char *) hostname);
     }
 }


### PR DESCRIPTION
Backport upstream commits:
- ee87746 - TLS server name indication support (#310)
- 565b73b - Fix segfault in TLS SNI code when callbacks not used (#315)

This adds mailstream_ssl_set_server_name() function that allows clients
to enable SNI on a TLS session by supplying the server name via a call
within the session open callback.

Supports both OpenSSL and GnuTLS backends. Without SNI, modern servers
like Gmail return invalid certificates causing ErrorCertificate failures.