### PR TITLE
Fix macOS IMAP SSL connection issue

### DIFF
--- a/Vendor/libetpan/src/low-level/imap/mailimap_ssl.c
+++ b/Vendor/libetpan/src/low-level/imap/mailimap_ssl.c
@@ -75,9 +75,8 @@ int mailimap_ssl_connect_voip_with_callback(mailimap * f, const char * server, u
 
 #if HAVE_CFNETWORK
   if (mailstream_cfstream_enabled) {
-    if (callback == NULL) {
-      return mailimap_cfssl_connect_voip(f, server, port, voip_enabled);
-    }
+    // CFNetwork handles SNI automatically via hostname - callback not needed
+    return mailimap_cfssl_connect_voip(f, server, port, voip_enabled);
   }
 #endif
   

--- a/Vendor/libetpan/src/low-level/pop3/mailpop3_ssl.c
+++ b/Vendor/libetpan/src/low-level/pop3/mailpop3_ssl.c
@@ -73,9 +73,8 @@ int mailpop3_ssl_connect_with_callback(mailpop3 * f, const char * server, uint16
 
 #if HAVE_CFNETWORK
   if (mailstream_cfstream_enabled) {
-    if (callback == NULL) {
-      return mailpop3_cfssl_connect(f, server, port);
-    }
+    // CFNetwork handles SNI automatically via hostname - callback not needed
+    return mailpop3_cfssl_connect(f, server, port);
   }
 #endif
   

--- a/Vendor/libetpan/src/low-level/smtp/mailsmtp_ssl.c
+++ b/Vendor/libetpan/src/low-level/smtp/mailsmtp_ssl.c
@@ -77,9 +77,8 @@ int mailsmtp_ssl_connect_with_callback(mailsmtp * session,
 
 #if HAVE_CFNETWORK
   if (mailstream_cfstream_enabled) {
-    if (callback == NULL) {
-      return mailsmtp_cfssl_connect(session, server, port);
-    }
+    // CFNetwork handles SNI automatically via hostname - callback not needed
+    return mailsmtp_cfssl_connect(session, server, port);
   }
 #endif
   


### PR DESCRIPTION
The SNI support commit (3e4aea3) broke SSL connections on macOS by passing callbacks to the SSL connect functions. On macOS with CFNetwork (HAVE_CFNETWORK=1), the previous code only used the CFNetwork path when callback == NULL, falling through to the OpenSSL path otherwise. Since macOS doesn't compile with OpenSSL, this caused connection failures.

The fix removes the callback == NULL check so CFNetwork is always used on macOS. This is correct because:
1. CFNetwork handles SNI automatically when connecting with a hostname
2. This matches the existing STARTTLS behavior which already ignores callbacks on CFNetwork (see "// won't use callback" comments)

Fixes IMAP, SMTP, and POP3 SSL connections on macOS.