### PR TITLE
Add Fedora 43 to our automated mailsync testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        fedora_version: ['40', '41']
+        fedora_version: ['40', '41', '43']
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/MailSync/MailspringDynamicTidy.cpp
+++ b/MailSync/MailspringDynamicTidy.cpp
@@ -60,12 +60,14 @@ void mailspring_tidy_init(void) {
         return; // Already initialized
     }
 
-    // Try different library names used by various Linux distributions
+    // Try different library names used by various Linux distributions.
+    // Using dlopen allows the binary to work regardless of which soname is
+    // available, avoiding RPM/DEB dependency issues on the specific soversion.
     const char* libraryNames[] = {
-        "libtidy.so.5",      // Fedora, Arch, generic
-        "libtidy.so.58",     // Some newer versions
-        "libtidy.so.5deb1",  // Debian/Ubuntu older
-        "libtidy.so.60",     // Ubuntu 24.04 (libtidy 5.8.0 uses soname 60)
+        "libtidy.so.5",      // Fedora <40, RHEL 7/8, Arch, generic
+        "libtidy.so.58",     // Fedora 40+, RHEL 9+, Alma, Rocky (libtidy 5.8.x)
+        "libtidy.so.5deb1",  // Debian/Ubuntu (Debian-patched versions)
+        "libtidy.so.60",     // Ubuntu 24.04+ (libtidy 5.8.0 with soname 60)
         "libtidy.so.6",      // Future versions
         "libtidy.so",        // Fallback (development symlink)
         nullptr


### PR DESCRIPTION
The mailsync binary already correctly supports multiple libtidy sonames via dlopen (including libtidy.so.58 used by Fedora 43, Alma, Rocky Linux).

This commit:
- Adds Fedora 43 to the CI test matrix to verify compatibility
- Updates comments to clarify which distributions use which sonames

The reported RPM dependency issue (libtidy.so.5 not found) is a packaging metadata problem in the main Mailspring repo, not a code issue here. The mailsync binary works correctly because it uses dlopen to load whichever libtidy soname is available at runtime.