### PR TITLE
Fix Yandex account sync error handling

### DIFF
--- a/MailSync/DAVWorker.cpp
+++ b/MailSync/DAVWorker.cpp
@@ -409,12 +409,6 @@ void DAVWorker::runContacts() {
         return;
     }
 
-    // Yandex returns a CardDAV host via DNS SRV but doesn't actually support CardDAV.
-    // PROPFIND requests to yandex.ru return HTTP 405 (Method Not Allowed).
-    if (account->IMAPHost().find("imap.yandex.com") != string::npos) {
-        return;
-    }
-
     // Discovery already completed but no address book found - nothing to sync
     if (contactsDiscoveryComplete && cachedAddressBook == nullptr) {
         return;
@@ -1143,12 +1137,6 @@ void DAVWorker::rebuildContactGroup(shared_ptr<Contact> contact) {
 
 void DAVWorker::runCalendars() {
     if (calHost == "") {
-        return;
-    }
-
-    // Yandex returns a CalDAV host via DNS SRV but doesn't actually support CalDAV.
-    // PROPFIND requests to yandex.ru return HTTP 405 (Method Not Allowed).
-    if (account->IMAPHost().find("imap.yandex.com") != string::npos) {
         return;
     }
 

--- a/MailSync/DAVWorker.cpp
+++ b/MailSync/DAVWorker.cpp
@@ -409,6 +409,12 @@ void DAVWorker::runContacts() {
         return;
     }
 
+    // Yandex returns a CardDAV host via DNS SRV but doesn't actually support CardDAV.
+    // PROPFIND requests to yandex.ru return HTTP 405 (Method Not Allowed).
+    if (account->IMAPHost().find("imap.yandex.com") != string::npos) {
+        return;
+    }
+
     // Discovery already completed but no address book found - nothing to sync
     if (contactsDiscoveryComplete && cachedAddressBook == nullptr) {
         return;
@@ -1137,6 +1143,12 @@ void DAVWorker::rebuildContactGroup(shared_ptr<Contact> contact) {
 
 void DAVWorker::runCalendars() {
     if (calHost == "") {
+        return;
+    }
+
+    // Yandex returns a CalDAV host via DNS SRV but doesn't actually support CalDAV.
+    // PROPFIND requests to yandex.ru return HTTP 405 (Method Not Allowed).
+    if (account->IMAPHost().find("imap.yandex.com") != string::npos) {
         return;
     }
 


### PR DESCRIPTION
Yandex advertises CardDAV/CalDAV hosts via DNS SRV records, but does not actually implement the DAV protocols. PROPFIND requests to yandex.ru return HTTP 405 (Method Not Allowed), causing crashes in the calContacts sync worker.

Add early returns in runContacts() and runCalendars() to skip DAV sync for accounts using imap.yandex.com, similar to how Gmail accounts skip CardDAV sync in favor of the Google Contacts API.