### PR TITLE
Fix EventRSVPTask to be RFC 5546/6047 compliant

### DIFF
--- a/Vendor/icalendarlib/icalendar.cpp
+++ b/Vendor/icalendarlib/icalendar.cpp
@@ -66,6 +66,9 @@ void ICalendar::LoadFromString(string icsData) {
 					NewEvent->Location = UnescapeICSText(GetProperty(Line));
 				} else if (Line.find("ATTENDEE") == 0) {
 					NewEvent->Attendees.push_back(ParseAttendee(Line, GetProperty(Line)));
+				} else if (Line.find("ORGANIZER") == 0) {
+					// ORGANIZER has same format as ATTENDEE: ORGANIZER;CN="Name":mailto:email
+					NewEvent->Organizer = ParseAttendee(Line, GetProperty(Line));
 				} else if (Line.find("BEGIN:VALARM") == 0) {
 					NewAlarm.Clear();
 					PrevComponent = CurrentComponent;

--- a/Vendor/icalendarlib/types.h
+++ b/Vendor/icalendarlib/types.h
@@ -61,6 +61,7 @@ struct ICalendarEvent {
 		RecurrenceId(Base.RecurrenceId),
 		Status(Base.Status),
 		Location(Base.Location),
+		Organizer(Base.Organizer),
 		Attendees(Base.Attendees),
 		DtStamp(Base.DtStamp),
 		DtStart(Base.DtStart),
@@ -82,6 +83,7 @@ struct ICalendarEvent {
 	string RecurrenceId;  // RECURRENCE-ID for exception instances (e.g., "20240115T100000Z")
 	string Status;        // STATUS: TENTATIVE, CONFIRMED, CANCELLED
 	string Location;      // LOCATION: physical or virtual location
+	string Organizer;     // ORGANIZER: event organizer (as "Name <email>" or just email) - RFC 5546 MUST for REPLY
 	list<string> Attendees;  // ATTENDEE: list of participants (each as "Name <email>" or just email)
 	Date DtStamp, DtStart, DtEnd;
 	Recurrence RRule;


### PR DESCRIPTION
This commit rewrites the performRemoteSendRSVP function to properly format and send iMIP RSVP replies according to RFC 5546 (iTIP) and RFC 6047 (iMIP) specifications.

MIME Structure Changes:
- Use multipart/alternative instead of multipart/mixed
- Set Content-Disposition: inline (not attachment)
- Add charset=UTF-8 to text/calendar Content-Type
- Include method=REPLY parameter in Content-Type header
- Use base64 Content-Transfer-Encoding for calendar part
- Add human-readable text/plain part with RSVP status message

RFC 5546 Validation (MUST requirements):
- Validate ICS contains METHOD:REPLY
- Validate UID property exists (must match original invitation)
- Validate DTSTAMP property exists
- Validate ORGANIZER property exists
- Validate exactly one ATTENDEE (the replying user)
- Validate ATTENDEE has valid PARTSTAT (ACCEPTED/DECLINED/TENTATIVE)

RFC 6047 Compliance:
- Warn when From address doesn't match ATTENDEE email
- Use icsRSVPStatus from task data for human-readable message

ICalendar Library Enhancement:
- Add ORGANIZER property parsing to support RFC 5546 validation