### PR TITLE
Improve iCloud compatibility by disabling QRESYNC

### DIFF
--- a/Vendor/mailcore2/src/core/imap/MCIMAPSession.cpp
+++ b/Vendor/mailcore2/src/core/imap/MCIMAPSession.cpp
@@ -4404,6 +4404,11 @@ bool IMAPSession::isQResyncEnabled()
     return mQResyncEnabled;
 }
 
+void IMAPSession::setQResyncEnabled(bool enabled)
+{
+    mQResyncEnabled = enabled;
+}
+
 bool IMAPSession::isIdentityEnabled()
 {
     return mIdentityEnabled;

--- a/Vendor/mailcore2/src/core/imap/MCIMAPSession.h
+++ b/Vendor/mailcore2/src/core/imap/MCIMAPSession.h
@@ -192,6 +192,7 @@ namespace mailcore {
         virtual bool isXListEnabled();
         virtual bool isCondstoreEnabled();
         virtual bool isQResyncEnabled();
+        virtual void setQResyncEnabled(bool enabled);
         virtual bool isIdentityEnabled();
         virtual bool isXOAuthEnabled();
         virtual bool isNamespaceEnabled();


### PR DESCRIPTION
iCloud's QRESYNC implementation has known issues documented at https://developer.apple.com/forums/thread/694251:

- Returns malformed VANISHED responses
- Doesn't send the ENABLED untagged response per RFC
- May return invalid sequence numbers in FETCH responses

These issues cause messages to be incorrectly detected as deleted, leading to emails "disappearing" from the local database.

This fix:
- Adds setQResyncEnabled() method to mailcore2 IMAPSession to allow disabling QRESYNC after capability detection
- Detects iCloud accounts by IMAP hostname (imap.mail.me.com)
- Disables QRESYNC after login so the session falls back to CONDSTORE with periodic deep scans for deletion detection
- Also disables the hasQResync flag in syncNow() for defense in depth

With QRESYNC disabled, iCloud accounts will use the more conservative sync approach: CONDSTORE for detecting modified messages, plus periodic deep scans (every 10 minutes) to detect deleted messages by comparing local UIDs against server UIDs.