### PR TITLE
Handle network errors gracefully during CardDAV/CalDAV discovery

### DIFF
--- a/MailSync/SyncException.cpp
+++ b/MailSync/SyncException.cpp
@@ -74,5 +74,6 @@ json SyncException::toJSON() {
         {"key", key},
         {"debuginfo", debuginfo},
         {"retryable", retryable},
+        {"offline", offline},
     };
 }


### PR DESCRIPTION
## Summary
Add error handling for network connectivity issues during CardDAV and CalDAV server discovery. When the server is unreachable due to DNS resolution failures, connection refused, or other offline conditions, the sync now gracefully skips that service instead of crashing.

## Changes
- **CardDAV discovery**: Added check for `isOffline()` errors in `runContacts()` to skip contact sync when the CardDAV server is unreachable
- **CalDAV discovery**: Added check for `isOffline()` errors in `runCalendars()` to skip calendar sync when the CalDAV server is unreachable
- Both handlers log informative messages indicating the server is unreachable and that sync is being skipped

## Implementation Details
- The error handling follows the existing pattern for unsupported server errors
- Network errors are caught during the discovery phase before attempting actual sync operations
- The `isOffline()` method is used to identify network-related exceptions
- Appropriate cleanup is performed (e.g., clearing cached address book in contacts sync)
- Logging includes the error key for debugging purposes