### PR TITLE
Fix memory leak in SyncWorker::syncFolderUIDRange

### DIFF
--- a/MailSync/SyncWorker.cpp
+++ b/MailSync/SyncWorker.cpp
@@ -764,7 +764,7 @@ void SyncWorker::syncFolderUIDRange(Folder & folder, Range range, bool heavyInit
 
     AutoreleasePool pool;
     IndexSet * set = IndexSet::indexSetWithRange(range);
-    IndexSet * heavyNeeded = new IndexSet();
+    IndexSet * heavyNeeded = IndexSet::indexSet();
     IMAPProgress cb;
     ErrorCode err(ErrorCode::ErrorNone);
     String path(AS_MCSTR(remotePath));

--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -1577,7 +1577,7 @@ void TaskProcessor::performRemoteSendDraft(Task * task) {
         // because multisend is capped.
         int tries = 0;
         int delay[] = {0, 1, 1, 2, 2};
-        IndexSet * uids = new IndexSet();
+        IndexSet * uids = IndexSet::indexSet();
         
         while (tries < 4 && uids->count() == 0) {
             if (delay[tries]) {


### PR DESCRIPTION
## Summary
Fixed a memory leak in the `syncFolderUIDRange` method by using the proper memory management pattern for IndexSet allocation.

## Changes
- Changed `IndexSet * heavyNeeded = new IndexSet();` to `IndexSet * heavyNeeded = IndexSet::indexSet();`
- This ensures the IndexSet object is properly managed by the autorelease pool declared at the beginning of the function, preventing manual memory management issues

## Details
The function already declares an `AutoreleasePool pool` at the start, which is the intended memory management mechanism for this code. By using the factory method `IndexSet::indexSet()` instead of direct `new` allocation, the object is automatically added to the autorelease pool and will be properly released when the pool is drained, eliminating the memory leak.