### PR TITLE
Add Ubuntu 25.04 support for libtidy58

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,7 +270,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        ubuntu_version: ['22.04', '24.04']
+        ubuntu_version: ['22.04', '24.04', '25.04']
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -286,15 +286,21 @@ jobs:
             # Install required runtime dependencies (from debian control.in)
             apt-get update
 
-            # libicu package name varies by Ubuntu version
+            # libicu and libtidy package names vary by Ubuntu version
             if [[ '${{ matrix.ubuntu_version }}' == '22.04' ]]; then
               LIBICU=libicu70
-            else
+              LIBTIDY=libtidy5deb1
+            elif [[ '${{ matrix.ubuntu_version }}' == '24.04' ]]; then
               LIBICU=libicu74
+              LIBTIDY=libtidy5deb1
+            else
+              # Ubuntu 25.04+: libicu76, libtidy58
+              LIBICU=libicu76
+              LIBTIDY=libtidy58
             fi
 
             apt-get install -y libcurl4 libssl3 \$LIBICU uuid-runtime libsasl2-2 \
-              libudev1 libgcrypt20 libxtst6 libglib2.0-bin xdg-utils libtidy5deb1 file
+              libudev1 libgcrypt20 libxtst6 libglib2.0-bin xdg-utils \$LIBTIDY file
 
             # Extract to a directory containing 'mailspring' in the path
             # (required by branding check in main.cpp that exits with code 2)

--- a/MailSync/MailspringDynamicTidy.cpp
+++ b/MailSync/MailspringDynamicTidy.cpp
@@ -65,9 +65,9 @@ void mailspring_tidy_init(void) {
     // available, avoiding RPM/DEB dependency issues on the specific soversion.
     const char* libraryNames[] = {
         "libtidy.so.5",      // Fedora <40, RHEL 7/8, Arch, generic
-        "libtidy.so.58",     // Fedora 40+, RHEL 9+, Alma, Rocky (libtidy 5.8.x)
-        "libtidy.so.5deb1",  // Debian/Ubuntu (Debian-patched versions)
-        "libtidy.so.60",     // Ubuntu 24.04+ (libtidy 5.8.0 with soname 60)
+        "libtidy.so.58",     // Fedora 40+, RHEL 9+, Alma, Rocky, Ubuntu 25.04+ (libtidy 5.8.x)
+        "libtidy.so.5deb1",  // Debian/Ubuntu 22.04-24.04 (Debian-patched versions)
+        "libtidy.so.60",     // Some distros with libtidy 5.8.0 soname 60
         "libtidy.so.6",      // Future versions
         "libtidy.so",        // Fallback (development symlink)
         nullptr


### PR DESCRIPTION
- Add Ubuntu 25.04 to GitHub Actions test matrix
- Update package installation to use libtidy58 and libicu76 for Ubuntu 25.04+
- Update dlopen comments to clarify which distros use libtidy.so.58

https://claude.ai/code/session_01WHt5Ya1xijSN9apjSXoRjK