### PR TITLE
  Fix TLS SNI handling and his fallback and make mailcore2 ctemplate optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ CMakeCache.txt
 CMakeFiles/
 Makefile
 cmake_install.cmake
+
+# Local generated build directories
+/build-local/
+/Vendor/mailcore2/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
 project (mailsync) 
 
 SET (CMAKE_CXX_FLAGS   "-Wno-unknown-pragmas")
@@ -15,6 +15,9 @@ link_directories (${GLIB_LIBRARY_DIRS})
 
 IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
+  set(LIBETPAN_VENDOR_LIB_DIR "${CMAKE_SOURCE_DIR}/Vendor/libetpan/src/.libs")
+  set(LIBETPAN_VENDOR_SO "${LIBETPAN_VENDOR_LIB_DIR}/libetpan.so")
+
   set(additional_includes
     /usr/include/tidy
     /usr/include/libxml2
@@ -26,6 +29,7 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
   link_directories(/opt/openssl/lib)
   link_directories(Vendor/mailcore2/build/src)
+  link_directories(${LIBETPAN_VENDOR_LIB_DIR})
   include_directories(Vendor/mailcore2/build/src/include)
 
   include_directories(Vendor)
@@ -50,11 +54,27 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
   add_executable(mailsync MailSync/main.cpp ${SOURCES})
 
+  if(EXISTS "${LIBETPAN_VENDOR_SO}")
+    set(MAILSYNC_LIBETPAN_LIBRARY "${LIBETPAN_VENDOR_SO}")
+    message(STATUS "Using vendored libetpan: ${MAILSYNC_LIBETPAN_LIBRARY}")
+  else()
+    find_library(MAILSYNC_LIBETPAN_LIBRARY NAMES etpan)
+    if(NOT MAILSYNC_LIBETPAN_LIBRARY)
+      message(FATAL_ERROR "Could not find libetpan (vendored or system)")
+    endif()
+    message(STATUS "Using system libetpan: ${MAILSYNC_LIBETPAN_LIBRARY}")
+  endif()
+
+  set_target_properties(mailsync PROPERTIES
+    BUILD_RPATH "\$ORIGIN;\$ORIGIN/..;${LIBETPAN_VENDOR_LIB_DIR};${CMAKE_SOURCE_DIR}/Vendor/mailcore2/build/src;/opt/openssl/lib"
+    INSTALL_RPATH "\$ORIGIN;\$ORIGIN/.."
+  )
+
   add_definitions(-DSQLITE_ENABLE_FTS5=1 -DHAVE_USLEEP=1 -DSQLITE_OMIT_LOAD_EXTENSION=1)
 
   target_link_libraries(mailsync libMailCore.a)
   target_link_libraries(mailsync ${GLIB_LIBRARIES})
-  target_link_libraries(mailsync libetpan.a)
+  target_link_libraries(mailsync ${MAILSYNC_LIBETPAN_LIBRARY})
 
   find_library(XML_LIB NAMES libxml2.a libxml2)
   target_link_libraries(mailsync ${XML_LIB})
@@ -68,9 +88,6 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
   find_library(RESOLV_LIB NAMES libresolv.a libresolv)
   target_link_libraries(mailsync ${RESOLV_LIB})
-
-  find_library(CTEMPLATE_LIB NAMES libctemplate.a libctemplate)
-  target_link_libraries(mailsync ${CTEMPLATE_LIB})
 
   find_library(UUID_LIB NAMES libuuid.a libuuid)
   target_link_libraries(mailsync ${UUID_LIB})

--- a/Vendor/libetpan/src/data-types/mailstream_ssl.h
+++ b/Vendor/libetpan/src/data-types/mailstream_ssl.h
@@ -124,6 +124,10 @@ int mailstream_ssl_set_server_certicate(struct mailstream_ssl_context * ssl_cont
     char * CAfile, char * CApath);
 
 LIBETPAN_EXPORT
+int mailstream_ssl_set_server_name(struct mailstream_ssl_context * ssl_context,
+    const char * server_name);
+
+LIBETPAN_EXPORT
 void * mailstream_ssl_get_openssl_ssl_ctx(struct mailstream_ssl_context * ssl_context);
 
 LIBETPAN_EXPORT

--- a/Vendor/libetpan/src/low-level/imap/mailimap_ssl.c
+++ b/Vendor/libetpan/src/low-level/imap/mailimap_ssl.c
@@ -53,6 +53,24 @@
 
 #include "mailstream_cfstream.h"
 
+struct mailimap_ssl_callback_data {
+  void (* callback)(struct mailstream_ssl_context * ssl_context, void * data);
+  void * data;
+  const char * server;
+};
+
+static void mailimap_ssl_sni_callback(struct mailstream_ssl_context * ssl_context, void * data)
+{
+  struct mailimap_ssl_callback_data * callback_data = (struct mailimap_ssl_callback_data *) data;
+
+  if (callback_data != NULL && callback_data->server != NULL) {
+    mailstream_ssl_set_server_name(ssl_context, callback_data->server);
+  }
+  if (callback_data != NULL && callback_data->callback != NULL) {
+    callback_data->callback(ssl_context, callback_data->data);
+  }
+}
+
 #define DEFAULT_IMAPS_PORT 993
 #define SERVICE_NAME_IMAPS "imaps"
 #define SERVICE_TYPE_TCP "tcp"
@@ -72,6 +90,7 @@ int mailimap_ssl_connect_voip_with_callback(mailimap * f, const char * server, u
 {
   int s;
   mailstream * stream;
+  struct mailimap_ssl_callback_data callback_data;
 
 #if HAVE_CFNETWORK
   if (mailstream_cfstream_enabled) {
@@ -93,7 +112,11 @@ int mailimap_ssl_connect_voip_with_callback(mailimap * f, const char * server, u
   if (s == -1)
     return MAILIMAP_ERROR_CONNECTION_REFUSED;
 
-  stream = mailstream_ssl_open_with_callback_timeout(s, f->imap_timeout, callback, data);
+  callback_data.callback = callback;
+  callback_data.data = data;
+  callback_data.server = server;
+  stream = mailstream_ssl_open_with_callback_timeout(s, f->imap_timeout,
+    mailimap_ssl_sni_callback, &callback_data);
   if (stream == NULL) {
 #ifdef WIN32
 	closesocket(s);

--- a/Vendor/libetpan/src/low-level/pop3/mailpop3_ssl.c
+++ b/Vendor/libetpan/src/low-level/pop3/mailpop3_ssl.c
@@ -42,6 +42,24 @@
 #include "mailpop3.h"
 #include "mailstream_cfstream.h"
 
+struct mailpop3_ssl_callback_data {
+  void (* callback)(struct mailstream_ssl_context * ssl_context, void * data);
+  void * data;
+  const char * server;
+};
+
+static void mailpop3_ssl_sni_callback(struct mailstream_ssl_context * ssl_context, void * data)
+{
+  struct mailpop3_ssl_callback_data * callback_data = (struct mailpop3_ssl_callback_data *) data;
+
+  if (callback_data != NULL && callback_data->server != NULL) {
+    mailstream_ssl_set_server_name(ssl_context, callback_data->server);
+  }
+  if (callback_data != NULL && callback_data->callback != NULL) {
+    callback_data->callback(ssl_context, callback_data->data);
+  }
+}
+
 #include "connect.h"
 #ifdef HAVE_NETINET_IN_H
 #	include <netinet/in.h>
@@ -70,6 +88,7 @@ int mailpop3_ssl_connect_with_callback(mailpop3 * f, const char * server, uint16
 {
   int s;
   mailstream * stream;
+  struct mailpop3_ssl_callback_data callback_data;
 
 #if HAVE_CFNETWORK
   if (mailstream_cfstream_enabled) {
@@ -91,7 +110,11 @@ int mailpop3_ssl_connect_with_callback(mailpop3 * f, const char * server, uint16
   if (s == -1)
     return MAILPOP3_ERROR_CONNECTION_REFUSED;
 
-  stream = mailstream_ssl_open_with_callback_timeout(s, f->pop3_timeout, callback, data);
+  callback_data.callback = callback;
+  callback_data.data = data;
+  callback_data.server = server;
+  stream = mailstream_ssl_open_with_callback_timeout(s, f->pop3_timeout,
+    mailpop3_ssl_sni_callback, &callback_data);
   if (stream == NULL) {
 #ifdef WIN32
 	closesocket(s);

--- a/Vendor/mailcore2/CMakeLists.txt
+++ b/Vendor/mailcore2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.5)
 project (mailcore2) 
 
 IF(APPLE)
@@ -78,7 +78,7 @@ IF(ANDROID)
   message(STATUS "Android platform")
 ELSE()
 
-# detect ctemplate
+# detect ctemplate (optional)
 
 find_path(CTEMPLATE_INCLUDE_DIR
   NAMES ctemplate/template.h
@@ -90,7 +90,7 @@ find_library(CTEMPLATE_LIBRARY
 )
 
 if(NOT CTEMPLATE_INCLUDE_DIR OR NOT CTEMPLATE_LIBRARY)
-  message(FATAL_ERROR "ERROR: Could not find ctemplate")
+  message(STATUS "ctemplate not found - continuing without it")
 else()
   message(STATUS "Found ctemplate")
 endif()

--- a/Vendor/mailcore2/src/core/renderer/MCHTMLRenderer.cpp
+++ b/Vendor/mailcore2/src/core/renderer/MCHTMLRenderer.cpp
@@ -8,7 +8,6 @@
 
 #include "MCHTMLRenderer.h"
 
-#include <ctemplate/template.h>
 #include "MCAddressDisplay.h"
 #include "MCDateFormatter.h"
 #include "MCSizeFormatter.h"

--- a/Vendor/mailcore2/tests/CMakeLists.txt
+++ b/Vendor/mailcore2/tests/CMakeLists.txt
@@ -13,9 +13,15 @@ IF(APPLE)
 ENDIF()
 
 add_executable (tests main.cpp test-all.cpp ${test_mac_files})
+
+set(CTEMPLATE_LINK_LIB)
+if(CTEMPLATE_LIBRARY)
+    set(CTEMPLATE_LINK_LIB ${CTEMPLATE_LIBRARY})
+endif()
+
 target_link_libraries (
     tests MailCore
     ${ZLIB_LIBRARY} ${LIBETPAN_LIBRARY} ${LIBXML_LIBRARY} ${UCHARDET_LIBRARY} sasl2
-    ${TIDY_LIBRARY} ${CTEMPLATE_LIBRARY} ssl crypto ${linux_libraries} ${mac_libraries}
+    ${TIDY_LIBRARY} ${CTEMPLATE_LINK_LIB} ssl crypto ${linux_libraries} ${mac_libraries}
     ${GLIB2_LIBRARIES} ${FOUNDATIONFRAMEWORK} ${SECURITYFRAMEWORK} ${CORESERVICESFRAMEWORK}
 )

--- a/Vendor/mailcore2/tests/CMakeLists.txt
+++ b/Vendor/mailcore2/tests/CMakeLists.txt
@@ -12,7 +12,14 @@ IF(APPLE)
     set(mac_libraries iconv)
 ENDIF()
 
-add_executable (tests main.cpp test-all.cpp ${test_mac_files})
+set(dynamic_tidy_sources)
+set(dynamic_tidy_libraries)
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set(dynamic_tidy_sources ../../../MailSync/MailspringDynamicTidy.cpp)
+    set(dynamic_tidy_libraries dl)
+ENDIF()
+
+add_executable (tests main.cpp test-all.cpp ${test_mac_files} ${dynamic_tidy_sources})
 
 set(CTEMPLATE_LINK_LIB)
 if(CTEMPLATE_LIBRARY)
@@ -23,5 +30,6 @@ target_link_libraries (
     tests MailCore
     ${ZLIB_LIBRARY} ${LIBETPAN_LIBRARY} ${LIBXML_LIBRARY} ${UCHARDET_LIBRARY} sasl2
     ${TIDY_LIBRARY} ${CTEMPLATE_LINK_LIB} ssl crypto ${linux_libraries} ${mac_libraries}
+    ${dynamic_tidy_libraries}
     ${GLIB2_LIBRARIES} ${FOUNDATIONFRAMEWORK} ${SECURITYFRAMEWORK} ${CORESERVICESFRAMEWORK}
 )

--- a/Vendor/mailcore2/unittest/CMakeLists.txt
+++ b/Vendor/mailcore2/unittest/CMakeLists.txt
@@ -7,7 +7,14 @@ link_directories(
     ${additional_lib_searchpath}
 )
 
-add_executable (unittestcpp unittest.cpp)
+set(dynamic_tidy_sources)
+set(dynamic_tidy_libraries)
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set(dynamic_tidy_sources ../../../MailSync/MailspringDynamicTidy.cpp)
+    set(dynamic_tidy_libraries dl)
+ENDIF()
+
+add_executable (unittestcpp unittest.cpp ${dynamic_tidy_sources})
 
 set(CTEMPLATE_LINK_LIB)
 if(CTEMPLATE_LIBRARY)
@@ -18,5 +25,6 @@ target_link_libraries (
     unittestcpp MailCore
     ${ZLIB_LIBRARY} ${LIBETPAN_LIBRARY} ${LIBXML_LIBRARY} ${UCHARDET_LIBRARY} sasl2
     ${TIDY_LIBRARY} ${CTEMPLATE_LINK_LIB} ssl crypto ${linux_libraries} ${mac_libraries}
+    ${dynamic_tidy_libraries}
     ${GLIB2_LIBRARIES} ${FOUNDATIONFRAMEWORK} ${SECURITYFRAMEWORK} ${CORESERVICESFRAMEWORK}
 )

--- a/Vendor/mailcore2/unittest/CMakeLists.txt
+++ b/Vendor/mailcore2/unittest/CMakeLists.txt
@@ -8,9 +8,15 @@ link_directories(
 )
 
 add_executable (unittestcpp unittest.cpp)
+
+set(CTEMPLATE_LINK_LIB)
+if(CTEMPLATE_LIBRARY)
+    set(CTEMPLATE_LINK_LIB ${CTEMPLATE_LIBRARY})
+endif()
+
 target_link_libraries (
     unittestcpp MailCore
     ${ZLIB_LIBRARY} ${LIBETPAN_LIBRARY} ${LIBXML_LIBRARY} ${UCHARDET_LIBRARY} sasl2
-    ${TIDY_LIBRARY} ${CTEMPLATE_LIBRARY} ssl crypto ${linux_libraries} ${mac_libraries}
+    ${TIDY_LIBRARY} ${CTEMPLATE_LINK_LIB} ssl crypto ${linux_libraries} ${mac_libraries}
     ${GLIB2_LIBRARIES} ${FOUNDATIONFRAMEWORK} ${SECURITYFRAMEWORK} ${CORESERVICESFRAMEWORK}
 )


### PR DESCRIPTION
 Ignore generated local build directories
 Fix mailcore2 test targets by linking dynamic tidy wrapper
 Merge tls-gmail-certificate-fix into origin/master with conflict resolution
 Fix TLS SNI handling and make mailcore2 ctemplate optional
 Update CMake configuration and improve certificate loading in mailcore2