### PR TITLE
Add biographies field to Google Contacts sync

### DIFF
--- a/MailSync/GoogleContactsWorker.cpp
+++ b/MailSync/GoogleContactsWorker.cpp
@@ -24,8 +24,8 @@
 #include <string>
 #include <curl/curl.h>
 
-string PERSON_FIELDS        = "emailAddresses,genders,names,nicknames,phoneNumbers,urls,birthdays,addresses,userDefined,relations,occupations,organizations,photos";
-string PERSON_UPDATE_FIELDS = "emailAddresses,genders,names,nicknames,phoneNumbers,urls,birthdays,addresses,userDefined,relations,occupations,organizations";
+string PERSON_FIELDS        = "emailAddresses,genders,names,nicknames,phoneNumbers,urls,birthdays,addresses,userDefined,relations,occupations,organizations,photos,biographies";
+string PERSON_UPDATE_FIELDS = "emailAddresses,genders,names,nicknames,phoneNumbers,urls,birthdays,addresses,userDefined,relations,occupations,organizations,biographies";
 string GOOGLE_PEOPLE_ROOT = "https://people.googleapis.com/v1/";
 
 GoogleContactsWorker::GoogleContactsWorker(shared_ptr<Account> account) :


### PR DESCRIPTION
## Summary
Extended Google Contacts synchronization to include the biographies field when fetching and updating contact information.

## Changes
- Added `biographies` field to `PERSON_FIELDS` constant to include biography data when retrieving contacts from Google People API
- Added `biographies` field to `PERSON_UPDATE_FIELDS` constant to support updating biography information when syncing contacts back to Google

## Details
These changes enable the MailSync application to sync contact biography/notes information with Google Contacts. The biographies field is now included in both read operations (PERSON_FIELDS) and write operations (PERSON_UPDATE_FIELDS) to ensure bidirectional synchronization of this contact attribute.

https://claude.ai/code/session_01LRiweWHKjfhntjX2sdiU1j