### PR TITLE
Force HTTP/1.1 for delta streaming and handle HTTP/2 errors

### DIFF
--- a/MailSync/MetadataWorker.cpp
+++ b/MailSync/MetadataWorker.cpp
@@ -125,6 +125,11 @@ void MetadataWorker::fetchDeltasBlocking() {
     curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, _onDeltaData);
     curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)this);
 
+    // Force HTTP/1.1 for the streaming connection. HTTP/2 multiplexing provides no
+    // benefit for a single long-lived stream, and HTTP/2 framing errors (CURLE_HTTP2,
+    // CURLE_HTTP2_STREAM) from load balancers and proxies cause unnecessary disconnects.
+    curl_easy_setopt(curl_handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+
     // close the connection if we receive <1 byte/sec for 30 seconds.
     // the backend sends 16 bytes (16 x "\n") every 10 sec, giving
     // 1.06 - 1.6 bytes every 30 sec depending on whether 2 or 3 packets

--- a/MailSync/SyncException.cpp
+++ b/MailSync/SyncException.cpp
@@ -34,6 +34,8 @@ SyncException::SyncException(CURLcode c, string di) :
         (c == CURLE_GOT_NOTHING) ||
         (c == CURLE_SEND_ERROR) ||
         (c == CURLE_RECV_ERROR) ||
+        (c == CURLE_HTTP2) ||
+        (c == CURLE_HTTP2_STREAM) ||
         (c == CURLE_AGAIN)) {
         retryable = true;
         offline = true;


### PR DESCRIPTION
## Summary
This change improves the reliability of the delta streaming connection by forcing HTTP/1.1 protocol and properly handling HTTP/2-related errors that can occur with certain load balancers and proxies.

## Key Changes
- **Force HTTP/1.1 for delta streaming**: Added `CURLOPT_HTTP_VERSION` option set to `CURL_HTTP_VERSION_1_1` in `fetchDeltasBlocking()`. HTTP/2 multiplexing provides no benefit for a single long-lived stream and can cause unnecessary disconnects due to framing errors from intermediary proxies.
- **Handle HTTP/2 errors as retryable**: Added `CURLE_HTTP2` and `CURLE_HTTP2_STREAM` error codes to the retryable error list in `SyncException`, allowing the sync to gracefully recover from HTTP/2-related failures.

## Implementation Details
- The HTTP/1.1 enforcement is applied directly to the curl handle used for the delta streaming connection
- HTTP/2 errors are now treated as offline/retryable errors, consistent with other transient network errors like `CURLE_SEND_ERROR` and `CURLE_RECV_ERROR`

https://claude.ai/code/session_0187FVMEsBrMWizgZUbkFQc3