### PR TITLE
Improve mailsync wrapper script environment variable handling

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ elif [[ "$OSTYPE" == "linux-gnu" ]]; then
   MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH)
   cp /usr/lib/${MULTIARCH}/sasl2/* "$APP_ROOT_DIR"
 
-  printf "#!/bin/bash\nset -e\nset -o pipefail\nSCRIPTPATH=\"\$( cd \"\$(dirname \"\$0\")\" >/dev/null 2>&1 ; pwd -P )\"\nSASL_PATH=\"\$SCRIPTPATH\" LD_LIBRARY_PATH=\"\$SCRIPTPATH:\$LD_LIBRARY_PATH\" \"\$SCRIPTPATH/mailsync.bin\" \"\$@\"" > "$APP_ROOT_DIR/mailsync"
+  printf "#!/bin/bash\nset -e\nset -o pipefail\nSCRIPTPATH=\"\$( cd \"\$(dirname \"\$0\")\" >/dev/null 2>&1 ; pwd -P )\"\nexport SASL_PATH=\"\$SCRIPTPATH\"\nexport LD_LIBRARY_PATH=\"\$SCRIPTPATH:\$LD_LIBRARY_PATH\"\nexec \"\$SCRIPTPATH/mailsync.bin\" \"\$@\"" > "$APP_ROOT_DIR/mailsync"
   chmod +x "$APP_ROOT_DIR/mailsync"
 
   # Zip this stuff up so we can push it to S3 as a single artifacts


### PR DESCRIPTION
## Summary
Updated the mailsync wrapper script generation in the Linux build process to properly export environment variables and use `exec` for cleaner process management.

## Key Changes
- Changed `SASL_PATH` and `LD_LIBRARY_PATH` assignments to use `export` statements, ensuring they are properly propagated to the mailsync.bin process
- Replaced inline variable assignment with explicit `export` declarations for better clarity and reliability
- Added `exec` before the mailsync.bin invocation to replace the shell process, improving process hierarchy and signal handling

## Implementation Details
These changes ensure that:
1. Environment variables are properly exported rather than just set in the current shell context
2. The mailsync.bin process runs as a direct child of the calling process (via `exec`), which is important for proper signal handling and process management
3. The wrapper script is more maintainable with explicit export statements on separate lines

https://claude.ai/code/session_01TEFo1y7kgfu5D4vfRWhakY