### PR TITLE
Add bulk RFC2822 message export functionality

### DIFF
--- a/MailSync/MailStore.hpp
+++ b/MailSync/MailStore.hpp
@@ -138,12 +138,6 @@ public:
         if (query.getLimit() != 0) {
             sql = sql + " LIMIT " + to_string(query.getLimit());
         }
-        if (query.getOffset() != 0) {
-            if (query.getLimit() == 0) {
-                sql = sql + " LIMIT -1";
-            }
-            sql = sql + " OFFSET " + to_string(query.getOffset());
-        }
         SQLite::Statement statement(this->_db, sql);
         query.bind(statement);
         

--- a/MailSync/MailStore.hpp
+++ b/MailSync/MailStore.hpp
@@ -138,6 +138,12 @@ public:
         if (query.getLimit() != 0) {
             sql = sql + " LIMIT " + to_string(query.getLimit());
         }
+        if (query.getOffset() != 0) {
+            if (query.getLimit() == 0) {
+                sql = sql + " LIMIT -1";
+            }
+            sql = sql + " OFFSET " + to_string(query.getOffset());
+        }
         SQLite::Statement statement(this->_db, sql);
         query.bind(statement);
         
@@ -150,6 +156,16 @@ public:
     }
     
     
+    template<typename ModelClass>
+    int count(Query & query) {
+        assertCorrectThread();
+        string sql = "SELECT COUNT(*) FROM " + ModelClass::TABLE_NAME + query.getSQL();
+        SQLite::Statement statement(this->_db, sql);
+        query.bind(statement);
+        statement.executeStep();
+        return statement.getColumn(0).getInt();
+    }
+
     /**
      Handles dividing a large set into small chunks of <1000 and re-aggregating the results so SQLite can handle it.
      */

--- a/MailSync/Query.cpp
+++ b/MailSync/Query.cpp
@@ -19,7 +19,7 @@ using namespace std;
 
 // TODO: figure out how to use templates for this
 
-Query::Query() noexcept : _clauses({}), _limit(0), _offset(0), _orderBy(""), _orderDir("ASC") {
+Query::Query() noexcept : _clauses({}), _limit(0), _orderBy(""), _orderDir("ASC") {
 }
 
 Query & Query::equal(string col, string val) {
@@ -70,11 +70,6 @@ Query & Query::limit(int l) {
     return *this;
 }
 
-Query & Query::offset(int o) {
-    _offset = o;
-    return *this;
-}
-
 Query & Query::orderBy(string col, string dir) {
     _orderBy = col;
     _orderDir = dir;
@@ -83,10 +78,6 @@ Query & Query::orderBy(string col, string dir) {
 
 int Query::getLimit() {
     return _limit;
-}
-
-int Query::getOffset() {
-    return _offset;
 }
 
 string Query::getSQL() {

--- a/MailSync/Query.cpp
+++ b/MailSync/Query.cpp
@@ -19,7 +19,7 @@ using namespace std;
 
 // TODO: figure out how to use templates for this
 
-Query::Query() noexcept : _clauses({}), _limit(0) {
+Query::Query() noexcept : _clauses({}), _limit(0), _offset(0) {
 }
 
 Query & Query::equal(string col, string val) {
@@ -70,8 +70,17 @@ Query & Query::limit(int l) {
     return *this;
 }
 
+Query & Query::offset(int o) {
+    _offset = o;
+    return *this;
+}
+
 int Query::getLimit() {
     return _limit;
+}
+
+int Query::getOffset() {
+    return _offset;
 }
 
 string Query::getSQL() {

--- a/MailSync/Query.cpp
+++ b/MailSync/Query.cpp
@@ -19,7 +19,7 @@ using namespace std;
 
 // TODO: figure out how to use templates for this
 
-Query::Query() noexcept : _clauses({}), _limit(0), _offset(0) {
+Query::Query() noexcept : _clauses({}), _limit(0), _offset(0), _orderBy(""), _orderDir("ASC") {
 }
 
 Query & Query::equal(string col, string val) {
@@ -75,6 +75,12 @@ Query & Query::offset(int o) {
     return *this;
 }
 
+Query & Query::orderBy(string col, string dir) {
+    _orderBy = col;
+    _orderDir = dir;
+    return *this;
+}
+
 int Query::getLimit() {
     return _limit;
 }
@@ -109,6 +115,9 @@ string Query::getSQL() {
                 result += it.key() + " " + op + " ?";
             }
         }
+    }
+    if (!_orderBy.empty()) {
+        result += " ORDER BY " + _orderBy + " " + _orderDir;
     }
     return result;
 }

--- a/MailSync/Query.hpp
+++ b/MailSync/Query.hpp
@@ -25,6 +25,8 @@ class Query {
     json _clauses;
     int _limit;
     int _offset;
+    string _orderBy;
+    string _orderDir;
 
 public:
     Query() noexcept;
@@ -41,6 +43,7 @@ public:
 
     Query & limit(int l);
     Query & offset(int o);
+    Query & orderBy(string col, string dir = "ASC");
 
     int getLimit();
     int getOffset();

--- a/MailSync/Query.hpp
+++ b/MailSync/Query.hpp
@@ -24,7 +24,6 @@ using namespace std;
 class Query {
     json _clauses;
     int _limit;
-    int _offset;
     string _orderBy;
     string _orderDir;
 
@@ -42,11 +41,9 @@ public:
     Query & lte(string col, double val);
 
     Query & limit(int l);
-    Query & offset(int o);
     Query & orderBy(string col, string dir = "ASC");
 
     int getLimit();
-    int getOffset();
     std::string getSQL();
 
     void bind(SQLite::Statement & query);

--- a/MailSync/Query.hpp
+++ b/MailSync/Query.hpp
@@ -24,10 +24,11 @@ using namespace std;
 class Query {
     json _clauses;
     int _limit;
-    
+    int _offset;
+
 public:
     Query() noexcept;
-    
+
     Query & equal(string col, string val);
     Query & equal(string col, double val);
     Query & equal(string col, vector<string> & val);
@@ -39,8 +40,10 @@ public:
     Query & lte(string col, double val);
 
     Query & limit(int l);
+    Query & offset(int o);
 
     int getLimit();
+    int getOffset();
     std::string getSQL();
 
     void bind(SQLite::Statement & query);

--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -1970,6 +1970,8 @@ void TaskProcessor::performRemoteGetManyRFC2822(Task * task) {
     // to avoid skipping/duplicating messages if the folder changes during export.
     // This uses the MessageUIDScanIndex (accountId, remoteFolderId, remoteUID).
     while (true) {
+        AutoreleasePool pool;
+
         auto chunkQuery = Query()
             .equal("accountId", task->accountId())
             .equal("remoteFolderId", folderId)
@@ -1983,7 +1985,6 @@ void TaskProcessor::performRemoteGetManyRFC2822(Task * task) {
         }
 
         for (auto & msg : messages) {
-            AutoreleasePool pool;
             std::string filename = sanitizeEmlFilename(msg->subject(), msg->date(), globalIndex);
             std::string filepath = outputDir + FS_PATH_SEP + filename;
 

--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -30,6 +30,9 @@
 
 #include <sstream>
 #include <algorithm>
+#include <iomanip>
+#include <thread>
+#include <chrono>
 
 #if defined(_MSC_VER)
 #include <direct.h>
@@ -434,6 +437,9 @@ void TaskProcessor::performLocal(Task * task) {
         } else if (cname == "GetMessageRFC2822Task") {
             // nothing
 
+        } else if (cname == "GetManyRFC2822Task") {
+            // nothing — all work happens in performRemote
+
         } else if (cname == "EventRSVPTask") {
             // nothing
 
@@ -530,6 +536,9 @@ void TaskProcessor::performRemote(Task * task) {
 
             } else if (cname == "GetMessageRFC2822Task") {
                 performRemoteGetMessageRFC2822(task);
+
+            } else if (cname == "GetManyRFC2822Task") {
+                performRemoteGetManyRFC2822(task);
 
             } else if (cname == "EventRSVPTask") {
                 performRemoteSendRSVP(task);
@@ -1846,7 +1855,190 @@ void TaskProcessor::performRemoteGetMessageRFC2822(Task * task) {
 #endif
 }
 
+std::string TaskProcessor::sanitizeEmlFilename(const std::string & subject, time_t date, int index) {
+    // Start with the subject, or "untitled" if empty
+    std::string safe = subject.empty() ? "untitled" : subject;
 
+    // Truncate to 80 characters (respecting multi-byte boundaries isn't critical
+    // since illegal chars are replaced anyway, and truncation mid-char produces
+    // a replacement underscore at worst)
+    if (safe.size() > 80) {
+        safe.resize(80);
+    }
+
+    // Replace filesystem-illegal characters and control characters with '_'
+    for (size_t i = 0; i < safe.size(); i++) {
+        unsigned char c = static_cast<unsigned char>(safe[i]);
+        if (c <= 0x1f || c == 0x7f ||
+            safe[i] == '/' || safe[i] == '?' || safe[i] == '<' || safe[i] == '>' ||
+            safe[i] == '\\' || safe[i] == ':' || safe[i] == '*' || safe[i] == '|' || safe[i] == '"') {
+            safe[i] = '_';
+        }
+    }
+
+    // Strip trailing dots and spaces (Windows requirement)
+    while (!safe.empty() && (safe.back() == '.' || safe.back() == ' ')) {
+        safe.pop_back();
+    }
+    if (safe.empty()) {
+        safe = "untitled";
+    }
+
+    // Format date as YYYY-MM-DD in UTC
+    char dateBuf[16];
+    struct tm utc;
+#ifdef _MSC_VER
+    gmtime_s(&utc, &date);
+#else
+    gmtime_r(&date, &utc);
+#endif
+    strftime(dateBuf, sizeof(dateBuf), "%Y-%m-%d", &utc);
+
+    // Build filename: {index} - {subject} - {date}.eml
+    std::ostringstream oss;
+    oss << std::setw(5) << std::setfill('0') << index
+        << " - " << safe << " - " << dateBuf << ".eml";
+
+    std::string filename = oss.str();
+
+#ifdef _MSC_VER
+    // Clamp to 200 characters for Windows MAX_PATH safety
+    if (filename.size() > 200) {
+        // Rebuild with a truncated subject to fit
+        size_t overhead = 5 + 3 + 3 + strlen(dateBuf) + 4; // index + " - " + " - " + date + ".eml"
+        size_t maxSubject = 200 - overhead;
+        if (safe.size() > maxSubject) {
+            safe.resize(maxSubject);
+            // Re-strip trailing dots/spaces after truncation
+            while (!safe.empty() && (safe.back() == '.' || safe.back() == ' ')) {
+                safe.pop_back();
+            }
+            if (safe.empty()) safe = "untitled";
+        }
+        oss.str("");
+        oss.clear();
+        oss << std::setw(5) << std::setfill('0') << index
+            << " - " << safe << " - " << dateBuf << ".eml";
+        filename = oss.str();
+    }
+#endif
+
+    return filename;
+}
+
+void TaskProcessor::performRemoteGetManyRFC2822(Task * task) {
+    const auto folderId = task->data()["folderId"].get<string>();
+    const auto folderPath = task->data()["folderPath"].get<string>();
+    const auto outputDir = task->data()["outputDir"].get<string>();
+
+    // Query all messages in the folder
+    auto all = store->findAll<Message>(
+        Query().equal("accountId", task->accountId()).equal("remoteFolderId", folderId));
+
+    // Initialize or resume progress
+    int resumeIndex = 0;
+    if (task->data().count("progress") && task->data()["progress"].count("exported")) {
+        resumeIndex = task->data()["progress"]["exported"].get<int>();
+    }
+
+    json progress;
+    progress["total"] = (int)all.size();
+    progress["exported"] = resumeIndex;
+    progress["failed"] = 0;
+    progress["errors"] = json::array();
+
+    // If resuming, carry forward previous error count and errors
+    if (task->data().count("progress")) {
+        if (task->data()["progress"].count("failed")) {
+            progress["failed"] = task->data()["progress"]["failed"];
+        }
+        if (task->data()["progress"].count("errors")) {
+            progress["errors"] = task->data()["progress"]["errors"];
+        }
+    }
+
+    int total = (int)all.size();
+    int exported = resumeIndex;
+    int failed = progress["failed"].get<int>();
+    const int chunkSize = 50;
+
+    for (int i = resumeIndex; i < total; i++) {
+        {
+            AutoreleasePool pool;
+            auto & msg = all[i];
+            std::string filename = sanitizeEmlFilename(msg->subject(), msg->date(), i);
+            std::string filepath = outputDir + FS_PATH_SEP + filename;
+
+            IMAPProgress cb;
+            ErrorCode err = ErrorNone;
+
+            try {
+                Data * data = session->fetchMessageByUID(
+                    AS_MCSTR(folderPath), msg->remoteUID(), &cb, &err);
+
+                if (err != ErrorNone) {
+                    throw SyncException(err, "GetManyRFC2822 fetch");
+                }
+                if (data == nullptr) {
+                    throw SyncException(ErrorFetch, "GetManyRFC2822 - null data");
+                }
+
+#ifdef _MSC_VER
+                wstring_convert<codecvt_utf8<wchar_t>, wchar_t> convert;
+                data->writeToFile(AS_WIDE_MCSTR(convert.from_bytes(filepath)));
+#else
+                data->writeToFile(AS_MCSTR(filepath));
+#endif
+                exported++;
+            } catch (SyncException & ex) {
+                logger->error("GetManyRFC2822: failed to export message {} (UID {}): {}",
+                    msg->id(), msg->remoteUID(), ex.toJSON().dump());
+                failed++;
+                json errEntry;
+                errEntry["messageId"] = msg->id();
+                errEntry["subject"] = msg->subject();
+                errEntry["error"] = ex.toJSON()["error"];
+                progress["errors"].push_back(errEntry);
+            }
+        } // AutoreleasePool scope
+
+        // After each chunk of 50, save progress and check for cancellation
+        if ((i + 1) % chunkSize == 0 || i == total - 1) {
+            progress["exported"] = exported;
+            progress["failed"] = failed;
+            task->data()["progress"] = progress;
+            store->save(task);
+
+            // Re-read task from DB to check for cancellation
+            auto refreshed = store->find<Task>(Query().equal("id", task->id()));
+            if (refreshed != nullptr && refreshed->shouldCancel()) {
+                progress["cancelled"] = true;
+                task->data()["progress"] = progress;
+                store->save(task);
+                logger->info("GetManyRFC2822: cancelled after exporting {} of {} messages", exported, total);
+                return;
+            }
+
+            // Sleep to let sync and other tasks breathe
+            if (i < total - 1) {
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+            }
+        }
+    }
+
+    // Write final result
+    json result;
+    result["total"] = total;
+    result["exported"] = exported;
+    result["failed"] = failed;
+    result["outputDir"] = outputDir;
+    result["errors"] = progress["errors"];
+    task->data()["result"] = result;
+    store->save(task);
+
+    logger->info("GetManyRFC2822: completed. Exported {} of {} messages ({} failed)",
+        exported, total, failed);
+}
 
 void TaskProcessor::performRemoteSendRSVP(Task * task) {
     AutoreleasePool pool;

--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -1931,9 +1931,9 @@ void TaskProcessor::performRemoteGetManyRFC2822(Task * task) {
     const auto folderPath = task->data()["folderPath"].get<string>();
     const auto outputDir = task->data()["outputDir"].get<string>();
 
-    // Query all messages in the folder
-    auto all = store->findAll<Message>(
-        Query().equal("accountId", task->accountId()).equal("remoteFolderId", folderId));
+    // Get total count without loading all message objects into memory
+    auto countQuery = Query().equal("accountId", task->accountId()).equal("remoteFolderId", folderId);
+    int total = store->count<Message>(countQuery);
 
     // Initialize or resume progress
     int resumeIndex = 0;
@@ -1942,7 +1942,7 @@ void TaskProcessor::performRemoteGetManyRFC2822(Task * task) {
     }
 
     json progress;
-    progress["total"] = (int)all.size();
+    progress["total"] = total;
     progress["exported"] = resumeIndex;
     progress["failed"] = 0;
     progress["errors"] = json::array();
@@ -1957,16 +1957,23 @@ void TaskProcessor::performRemoteGetManyRFC2822(Task * task) {
         }
     }
 
-    int total = (int)all.size();
     int exported = resumeIndex;
     int failed = progress["failed"].get<int>();
     const int chunkSize = 50;
+    int globalIndex = resumeIndex;
 
-    for (int i = resumeIndex; i < total; i++) {
-        {
+    for (int chunkStart = resumeIndex; chunkStart < total; chunkStart += chunkSize) {
+        // Load one chunk of messages at a time via LIMIT/OFFSET
+        auto chunkQuery = Query()
+            .equal("accountId", task->accountId())
+            .equal("remoteFolderId", folderId)
+            .limit(chunkSize)
+            .offset(chunkStart);
+        auto messages = store->findAll<Message>(chunkQuery);
+
+        for (auto & msg : messages) {
             AutoreleasePool pool;
-            auto & msg = all[i];
-            std::string filename = sanitizeEmlFilename(msg->subject(), msg->date(), i);
+            std::string filename = sanitizeEmlFilename(msg->subject(), msg->date(), globalIndex);
             std::string filepath = outputDir + FS_PATH_SEP + filename;
 
             IMAPProgress cb;
@@ -2000,29 +2007,29 @@ void TaskProcessor::performRemoteGetManyRFC2822(Task * task) {
                 errEntry["error"] = ex.toJSON()["error"];
                 progress["errors"].push_back(errEntry);
             }
-        } // AutoreleasePool scope
 
-        // After each chunk of 50, save progress and check for cancellation
-        if ((i + 1) % chunkSize == 0 || i == total - 1) {
-            progress["exported"] = exported;
-            progress["failed"] = failed;
+            globalIndex++;
+        }
+
+        // After each chunk, save progress and check for cancellation
+        progress["exported"] = exported;
+        progress["failed"] = failed;
+        task->data()["progress"] = progress;
+        store->save(task);
+
+        // Re-read task from DB to check for cancellation
+        auto refreshed = store->find<Task>(Query().equal("id", task->id()));
+        if (refreshed != nullptr && refreshed->shouldCancel()) {
+            progress["cancelled"] = true;
             task->data()["progress"] = progress;
             store->save(task);
+            logger->info("GetManyRFC2822: cancelled after exporting {} of {} messages", exported, total);
+            return;
+        }
 
-            // Re-read task from DB to check for cancellation
-            auto refreshed = store->find<Task>(Query().equal("id", task->id()));
-            if (refreshed != nullptr && refreshed->shouldCancel()) {
-                progress["cancelled"] = true;
-                task->data()["progress"] = progress;
-                store->save(task);
-                logger->info("GetManyRFC2822: cancelled after exporting {} of {} messages", exported, total);
-                return;
-            }
-
-            // Sleep to let sync and other tasks breathe
-            if (i < total - 1) {
-                std::this_thread::sleep_for(std::chrono::seconds(1));
-            }
+        // Sleep to let sync and other tasks breathe
+        if (chunkStart + chunkSize < total) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
         }
     }
 

--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -38,11 +38,31 @@
 #include <direct.h>
 #include <codecvt>
 #include <locale>
+#include <sys/utime.h>
+#else
+#include <sys/time.h>
 #endif
 
 using namespace std;
 using namespace mailcore;
 using namespace nlohmann;
+
+static void setFileModificationTime(const string & filepath, time_t timestamp) {
+#ifdef _MSC_VER
+    wstring_convert<codecvt_utf8<wchar_t>, wchar_t> convert;
+    struct _utimbuf times;
+    times.actime = timestamp;
+    times.modtime = timestamp;
+    _wutime(convert.from_bytes(filepath).c_str(), &times);
+#else
+    struct timeval times[2];
+    times[0].tv_sec = timestamp;
+    times[0].tv_usec = 0;
+    times[1].tv_sec = timestamp;
+    times[1].tv_usec = 0;
+    utimes(filepath.c_str(), times);
+#endif
+}
 
 // A helper function that can move messages between folders and update the provided
 // messages remoteUIDs, even if UIDPLUS and/or MOVE extensions are not present.
@@ -1853,6 +1873,7 @@ void TaskProcessor::performRemoteGetMessageRFC2822(Task * task) {
 #else
     data->writeToFile(AS_MCSTR(filepath));
 #endif
+    setFileModificationTime(filepath, msg->date());
 }
 
 std::string TaskProcessor::sanitizeEmlFilename(const std::string & subject, time_t date, int index) {
@@ -2008,6 +2029,7 @@ void TaskProcessor::performRemoteGetManyRFC2822(Task * task) {
 #else
                 data->writeToFile(AS_MCSTR(filepath));
 #endif
+                setFileModificationTime(filepath, msg->date());
                 exported++;
             } catch (SyncException & ex) {
                 logger->error("GetManyRFC2822: failed to export message {} (UID {}): {}",

--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -1936,40 +1936,51 @@ void TaskProcessor::performRemoteGetManyRFC2822(Task * task) {
     int total = store->count<Message>(countQuery);
 
     // Initialize or resume progress
-    int resumeIndex = 0;
-    if (task->data().count("progress") && task->data()["progress"].count("exported")) {
-        resumeIndex = task->data()["progress"]["exported"].get<int>();
-    }
-
     json progress;
     progress["total"] = total;
-    progress["exported"] = resumeIndex;
+    progress["exported"] = 0;
     progress["failed"] = 0;
     progress["errors"] = json::array();
 
-    // If resuming, carry forward previous error count and errors
+    // If resuming, carry forward previous progress
+    uint32_t cursorUID = 0;
+    int globalIndex = 0;
     if (task->data().count("progress")) {
-        if (task->data()["progress"].count("failed")) {
-            progress["failed"] = task->data()["progress"]["failed"];
+        auto & prev = task->data()["progress"];
+        if (prev.count("exported")) {
+            progress["exported"] = prev["exported"];
+            globalIndex = prev["exported"].get<int>();
         }
-        if (task->data()["progress"].count("errors")) {
-            progress["errors"] = task->data()["progress"]["errors"];
+        if (prev.count("failed")) {
+            progress["failed"] = prev["failed"];
+        }
+        if (prev.count("errors")) {
+            progress["errors"] = prev["errors"];
+        }
+        if (prev.count("lastUID")) {
+            cursorUID = prev["lastUID"].get<uint32_t>();
         }
     }
 
-    int exported = resumeIndex;
+    int exported = progress["exported"].get<int>();
     int failed = progress["failed"].get<int>();
     const int chunkSize = 50;
-    int globalIndex = resumeIndex;
 
-    for (int chunkStart = resumeIndex; chunkStart < total; chunkStart += chunkSize) {
-        // Load one chunk of messages at a time via LIMIT/OFFSET
+    // Paginate through messages ordered by remoteUID ascending, using a cursor
+    // to avoid skipping/duplicating messages if the folder changes during export.
+    // This uses the MessageUIDScanIndex (accountId, remoteFolderId, remoteUID).
+    while (true) {
         auto chunkQuery = Query()
             .equal("accountId", task->accountId())
             .equal("remoteFolderId", folderId)
-            .limit(chunkSize)
-            .offset(chunkStart);
+            .gt("remoteUID", (double)cursorUID)
+            .orderBy("remoteUID", "ASC")
+            .limit(chunkSize);
         auto messages = store->findAll<Message>(chunkQuery);
+
+        if (messages.empty()) {
+            break;
+        }
 
         for (auto & msg : messages) {
             AutoreleasePool pool;
@@ -2008,12 +2019,14 @@ void TaskProcessor::performRemoteGetManyRFC2822(Task * task) {
                 progress["errors"].push_back(errEntry);
             }
 
+            cursorUID = msg->remoteUID();
             globalIndex++;
         }
 
-        // After each chunk, save progress and check for cancellation
+        // After each chunk, save progress (including cursor) and check for cancellation
         progress["exported"] = exported;
         progress["failed"] = failed;
+        progress["lastUID"] = cursorUID;
         task->data()["progress"] = progress;
         store->save(task);
 
@@ -2028,7 +2041,7 @@ void TaskProcessor::performRemoteGetManyRFC2822(Task * task) {
         }
 
         // Sleep to let sync and other tasks breathe
-        if (chunkStart + chunkSize < total) {
+        if ((int)messages.size() == chunkSize) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
         }
     }

--- a/MailSync/TaskProcessor.hpp
+++ b/MailSync/TaskProcessor.hpp
@@ -97,7 +97,11 @@ private:
 
     void performRemoteExpungeAllInFolder(Task * task);
     void performRemoteGetMessageRFC2822(Task * task);
+    void performRemoteGetManyRFC2822(Task * task);
     void performRemoteSendRSVP(Task * task);
+
+public:
+    static std::string sanitizeEmlFilename(const std::string & subject, time_t date, int index);
 
 };
 


### PR DESCRIPTION
## Summary
This PR adds support for exporting multiple messages from a folder as RFC2822 (.eml) files, with progress tracking, error handling, and cancellation support.

## Key Changes
- **New task type `GetManyRFC2822Task`**: Handles bulk export of messages from a folder to a local directory
  - Added handling in `performLocal()` and `performRemote()` dispatch methods
  - Implements `performRemoteGetManyRFC2822()` to execute the bulk export operation

- **Filename sanitization utility**: New `sanitizeEmlFilename()` static method that:
  - Generates safe filenames from message subject, date, and index
  - Removes/replaces filesystem-illegal characters (/, \, :, *, ?, <>, |, ", control chars)
  - Truncates to 80 characters initially, with additional Windows MAX_PATH safety (200 char limit)
  - Formats filenames as: `{index:05d} - {subject} - {YYYY-MM-DD}.eml`
  - Handles edge cases like empty subjects and trailing dots/spaces

- **Progress tracking and resumability**:
  - Saves progress after every 50 messages
  - Tracks total, exported, and failed counts
  - Maintains detailed error log with message IDs and subjects
  - Supports resuming interrupted exports from last checkpoint

- **Cancellation support**: Checks for cancellation requests after each chunk and gracefully stops

- **Added dependencies**: `<iomanip>`, `<thread>`, `<chrono>` for formatting, threading, and delays

## Implementation Details
- Uses existing `session->fetchMessageByUID()` to retrieve message data
- Implements platform-specific file writing (Windows wide-char conversion via `codecvt_utf8`)
- Includes 1-second sleep between chunks to prevent blocking other sync operations
- Comprehensive error handling with exception catching and detailed logging
- Cross-platform support for both Windows and Unix-like systems

https://claude.ai/code/session_01FsYiYN4J2Lxj4RxxYUCq22