### PR TITLE
mailcore2: cmake: bump c++ version to gnu++17

### DIFF
--- a/Vendor/mailcore2/CMakeLists.txt
+++ b/Vendor/mailcore2/CMakeLists.txt
@@ -25,7 +25,7 @@ IF(APPLE)
   set(mac_libraries iconv)
   
 ELSEIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  set(CMAKE_CXX_FLAGS "-std=gnu++0x")
+  set(CMAKE_CXX_FLAGS "-std=gnu++17")
   
   set(additional_includes
     /usr/include/tidy


### PR DESCRIPTION
mailcore2 depends on icu.
Recent icu headers require c++17 to build, so bump it.
The project builds fine with c++17, so this is an easy fix.

This patch is part of a series attempting to upstream the Flatpak patches.