### PR TITLE
mailcore2: minizip: add required cast

### DIFF
--- a/Vendor/mailcore2/src/core/zip/MiniZip/zip.c
+++ b/Vendor/mailcore2/src/core/zip/MiniZip/zip.c
@@ -1246,7 +1246,7 @@ extern int ZEXPORT zipOpenNewFileInZip4_64 (zipFile file, const char* filename, 
         unsigned char bufHead[RAND_HEAD_LEN];
         unsigned int sizeHead;
         zi->ci.encrypt = 1;
-        zi->ci.pcrc_32_tab = get_crc_table();
+        zi->ci.pcrc_32_tab = (const unsigned long*)get_crc_table();
         /*init_keys(password,zi->ci.keys,zi->ci.pcrc_32_tab);*/
 
         sizeHead=crypthead(password,bufHead,RAND_HEAD_LEN,zi->ci.keys,zi->ci.pcrc_32_tab,crcForCrypting);


### PR DESCRIPTION
const unsigned int* is not the same as const unsigned long* on all platforms, recent compiler s complain about it.  
This was fixed by the MiniZip project 14 years ago! https://github.com/zlib-ng/minizip-ng/blob/5cdf2ca001d6613bafb6530719d38ab15499e73f/unzip.c#L1776

This patch is part of a series attempting to upstream the Flatpak patches.