### PR TITLE
Promote draft metadata with thread: prefix to thread on send

### DIFF
--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -1761,19 +1761,36 @@ void TaskProcessor::performRemoteSendDraft(Task * task) {
     
     logger->info("-- Synced sent message (Sent UID {} = Local ID {})", sentFolderMessageUID, localMessage->id());
     
-    // retrieve the new message and queue metadata tasks on it
+    // retrieve the new message and queue metadata tasks on it.
+    // Metadata entries whose pluginId starts with "thread:" are promoted to the
+    // thread (with the prefix stripped) rather than attached to the message.
+    // This lets plugins declare thread-level intent at draft-write time.
+    static const string THREAD_PREFIX = "thread:";
     for (const auto & m : draft.metadata()) {
         auto pluginId = m["pluginId"].get<string>();
-        logger->info("-- Queueing task to attach {} draft metadata to new message.", pluginId);
-        
-        Task mTask{"SyncbackMetadataTask", account->id(), {
-            {"modelId", localMessage->id()},
-            {"modelClassName", "message"},
-            {"modelHeaderMessageId", localMessage->headerMessageId()},
-            {"pluginId", pluginId},
-            {"value", m["value"]},
-        }};
-        performLocal(&mTask); // will call save
+
+        if (pluginId.substr(0, THREAD_PREFIX.size()) == THREAD_PREFIX) {
+            string actualPluginId = pluginId.substr(THREAD_PREFIX.size());
+            string threadId = localMessage->threadId();
+            logger->info("-- Queueing task to attach {} draft metadata to thread {} (thread: prefix).", actualPluginId, threadId);
+            Task mTask{"SyncbackMetadataTask", account->id(), {
+                {"modelId", threadId},
+                {"modelClassName", "thread"},
+                {"pluginId", actualPluginId},
+                {"value", m["value"]},
+            }};
+            performLocal(&mTask); // will call save
+        } else {
+            logger->info("-- Queueing task to attach {} draft metadata to new message.", pluginId);
+            Task mTask{"SyncbackMetadataTask", account->id(), {
+                {"modelId", localMessage->id()},
+                {"modelClassName", "message"},
+                {"modelHeaderMessageId", localMessage->headerMessageId()},
+                {"pluginId", pluginId},
+                {"value", m["value"]},
+            }};
+            performLocal(&mTask); // will call save
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

When a draft has plugin metadata whose `pluginId` begins with `"thread:"`, the sync engine now strips the prefix and attaches the metadata to the **thread** rather than the sent message. This lets plugins like send-reminders declare thread-level intent at draft-write time and have the sync engine do the right thing at send time — no client-side polling, retries, or coordination needed.

## Change

In `MailSync/TaskProcessor.cpp` `performRemoteSendDraft`, the metadata loop now branches on the `"thread:"` prefix:

- `pluginId` starts with `"thread:"` → queue a `SyncbackMetadataTask` against the thread (`modelClassName = "thread"`, `modelId = localMessage->threadId()`), with the prefix stripped from the pluginId.
- Otherwise → existing behavior (attach to message).

## Why this works

`performLocal` on a `SyncbackMetadataTask` calls `performLocalSyncbackMetadata`, which uses `store->findGeneric(type, ...)` — it already handles both `"message"` and `"thread"` as the `modelClassName`. `performLocal` also persists the task via `store->save(task)` so `performRemote` later syncs the metadata to the identity server for cross-device sync, matching the existing behavior for message metadata.

## Test plan

- [ ] Send a draft with metadata pluginId `"thread:send-reminders"` and verify the metadata lands on the thread (not the sent message), with key `"send-reminders"`.
- [ ] Send a draft with a non-prefixed pluginId and verify existing behavior is unchanged (metadata attached to the message).
- [ ] Confirm both flows emit a `SyncbackMetadataTask` that completes and syncs to the identity server.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdZdvKr262feovmtTuFypQ)_