### PR TITLE
Support shared mailboxes: SMTP username for XOAUTH2, login-only SMTP test, optional helper folders

### DIFF
--- a/MailSync/MailUtils.cpp
+++ b/MailSync/MailUtils.cpp
@@ -818,7 +818,11 @@ void MailUtils::configureSessionForAccount(IMAPSession &session, shared_ptr<Acco
 void MailUtils::configureSessionForAccount(SMTPSession & session, shared_ptr<Account> account) {
     if (account->refreshToken() != "") {
         XOAuth2Parts parts = SharedXOAuth2TokenManager()->partsForAccount(account);
-        session.setUsername(AS_MCSTR(parts.username));
+        // O365 shared mailboxes authenticate IMAP as the shared mailbox, but SMTP AUTH
+        // only accepts the signed-in user's identity, so a distinct smtp_username must
+        // take precedence over the IMAP-derived XOAuth2 username here.
+        string smtpUsername = account->SMTPUsername() != "" ? account->SMTPUsername() : parts.username;
+        session.setUsername(AS_MCSTR(smtpUsername));
         session.setOAuth2Token(AS_MCSTR(parts.accessToken));
         session.setAuthType(AuthTypeXOAuth2);
     } else {

--- a/MailSync/Models/Account.cpp
+++ b/MailSync/Models/Account.cpp
@@ -152,6 +152,16 @@ bool Account::SMTPAllowInsecureSSL() {
     return _data["settings"]["smtp_allow_insecure_ssl"].get<bool>();
 }
 
+string Account::SMTPVerification() {
+    json & s = _data["settings"];
+    return s.count("smtp_verification") ? s["smtp_verification"].get<string>() : "";
+}
+
+bool Account::createHelperFolders() {
+    json & s = _data["settings"];
+    return s.count("create_helper_folders") ? s["create_helper_folders"].get<bool>() : true;
+}
+
 string Account::constructorName() {
     return _data["__cls"].get<string>();
 }

--- a/MailSync/Models/Account.hpp
+++ b/MailSync/Models/Account.hpp
@@ -57,6 +57,8 @@ public:
     string SMTPPassword();
     string SMTPSecurity();
     bool SMTPAllowInsecureSSL();
+    string SMTPVerification();
+    bool createHelperFolders();
 
     string tableName();
     string constructorName();

--- a/MailSync/SyncWorker.cpp
+++ b/MailSync/SyncWorker.cpp
@@ -587,7 +587,13 @@ vector<shared_ptr<Folder>> SyncWorker::syncFoldersAndLabels()
     // create required Mailspring folders if they don't exist
     // TODO: Consolidate this into role association code below, and make it
     // use the same business logic as creating / updating folders from tasks.
-    vector<string> mailspringFolders{"Snoozed"};
+    // Accounts with create_helper_folders=false (e.g. O365 shared mailboxes, where
+    // any folder we create is visible to every member of the mailbox) are skipped;
+    // features depending on these folders (snooze) are unavailable there.
+    vector<string> mailspringFolders{};
+    if (account->createHelperFolders()) {
+        mailspringFolders.push_back("Snoozed");
+    }
 
     for (string mailspringFolder : mailspringFolders) {
         string mailspringRole = mailspringFolder;

--- a/MailSync/main.cpp
+++ b/MailSync/main.cpp
@@ -340,7 +340,15 @@ int runTestAuth(shared_ptr<Account> account) {
     errorService = "smtp";
     smtp.setConnectionLogger(&alogger);
     MailUtils::configureSessionForAccount(smtp, account);
-    smtp.checkAccount(from, &err);
+    if (account->SMTPVerification() == "login") {
+        // checkAccount() transmits a real test email, which is wrong for accounts that
+        // may not have send rights (e.g. O365 shared mailboxes without "Send As") and
+        // would be visible to every member of a shared mailbox. Verify the connection
+        // and credentials only; send permission is exercised on first real send.
+        smtp.loginIfNeeded(&err);
+    } else {
+        smtp.checkAccount(from, &err);
+    }
     if (err != ErrorNone) {
         alogger.log("\n\nSASL_PATH: " + MailUtils::getEnvUTF8("SASL_PATH"));
 


### PR DESCRIPTION
## Summary

Three small, independently-defensible account settings that let Mailspring connect mailboxes accessed with another user's credentials — the immediate use case is **Office 365 shared mailboxes** (paired UI PR: Foundry376/Mailspring#2763). Each change is a no-op for existing accounts.

### 1. `smtp_username` is now honored for XOAUTH2 accounts (`MailUtils.cpp`)

O365 accepts a shared mailbox address as the **IMAP** XOAUTH2 identity (delegate needs "Full Access"), but **SMTP AUTH only accepts the signed-in user**, who then submits mail as the shared address (needs "Send As"). Previously `configureSessionForAccount(SMTPSession&)` used the IMAP-derived `XOAuth2Parts.username` for both sessions, so shared mailboxes failed with `535 5.7.3 Authentication unsuccessful` (verified against a live tenant). Now the SMTP session prefers `smtp_username` when set, falling back to the previous behavior. Existing OAuth accounts set `smtp_username == imap_username`, so nothing changes for them.

### 2. `smtp_verification: "login"` — verify SMTP without sending a test email (`main.cpp`, `Account.cpp/hpp`)

`runTestAuth`'s SMTP check calls `checkAccount()`, which transmits a real "Mailspring SMTP Test Email". For shared mailboxes this is wrong twice over: reading a shared mailbox must not require send rights (Full Access–only delegates are a normal, supported configuration), and the test email lands visibly in the shared mailbox for every member. With this setting the test verifies the connection and credentials only (`loginIfNeeded`); send permission is exercised on the first real send, where the server's error (e.g. `SendAsDenied`) is the accurate signal. Accounts without the setting keep the full `checkAccount()` behavior.

### 3. `create_helper_folders: false` — skip provisioning "Snoozed" (`SyncWorker.cpp`, `Account.cpp/hpp`)

`syncFoldersAndLabels` unconditionally creates the "Snoozed" helper folder on every account. Any folder created in a shared mailbox is visible to every member, so accounts with this setting skip provisioning (snooze is unavailable for them — the paired UI PR documents this; a follow-up could hide the snooze UI for such accounts). Accounts without the setting are unchanged.

## Testing

- Verified on a live O365 tenant: a shared mailbox connects with Full Access only; IMAP folder list and inbox sync work; no test email is sent; no `Mailspring/Snoozed` folder is created in the shared mailbox.
- Before change 1, the same tenant reproducibly failed at SMTP with `535 5.7.3` when the shared address was used as the XOAUTH2 SMTP identity.
- Existing Gmail/O365/IMAP account adds still run the unchanged `checkAccount()` path (settings absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
