### PR TITLE
Fall back to ad-hoc signing when copying mailsync into ../app

### DIFF
--- a/MailSync.xcodeproj/project.pbxproj
+++ b/MailSync.xcodeproj/project.pbxproj
@@ -672,7 +672,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# copy mailsync and it's DYSM into the ../app directory\ncp \"${BUILT_PRODUCTS_DIR}/mailsync\" \"${PROJECT_DIR}/../app\"\necho \"Copied to app dir\"\n\n# explicitly codesign the binary because the codesigning build\n# phase is /AFTER/ this script is run. WTF.\ncodesign -s \"Mac Developer:\" -f \"${PROJECT_DIR}/../app/mailsync\"\necho \"Codesigned\"\n\nif [ -e \"${BUILT_PRODUCTS_DIR}/mailsync.dSYM\" ]\n  then cd \"${BUILT_PRODUCTS_DIR}\" && /usr/bin/zip -r \"${PROJECT_DIR}/../app/mailsync.dSYM.zip\" \"mailsync.dSYM\"\nfi\n";
+			shellScript = "# copy mailsync and it's DYSM into the ../app directory\ncp \"${BUILT_PRODUCTS_DIR}/mailsync\" \"${PROJECT_DIR}/../app\"\necho \"Copied to app dir\"\n\n# explicitly codesign the binary because the codesigning build\n# phase is /AFTER/ this script is run. WTF.\n# Try the developer identity, but fall back to ad-hoc signing (-s -) when it\n# isn't available so the copied binary still runs: macOS kills unsigned arm64\n# binaries on launch. Release builds are re-signed by electron-osx-sign.\ncodesign -s \"Mac Developer:\" -f \"${PROJECT_DIR}/../app/mailsync\" 2>/dev/null || codesign -s - -f \"${PROJECT_DIR}/../app/mailsync\"\necho \"Codesigned\"\n\nif [ -e \"${BUILT_PRODUCTS_DIR}/mailsync.dSYM\" ]\n  then cd \"${BUILT_PRODUCTS_DIR}\" && /usr/bin/zip -r \"${PROJECT_DIR}/../app/mailsync.dSYM.zip\" \"mailsync.dSYM\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
## Problem

The "copy mailsync into ../app" build phase signs the copied binary with:

```sh
codesign -s "Mac Developer:" -f "${PROJECT_DIR}/../app/mailsync"
```

`"Mac Developer"` is Apple's **legacy** development-certificate name (modern certs are "Apple Development" / "Developer ID Application"), so on a machine without a cert matching that name — most people building from source today — this `codesign` fails. The script's last statement is the dSYM-zip block, which returns 0, so the failure is swallowed and the build "succeeds" with **`../app/mailsync` left unsigned**.

On Apple Silicon, macOS kills unsigned arm64 binaries on launch. The mailsync process therefore dies immediately with a signal, and Mailspring surfaces it as a generic *"We encountered a problem with your local email database. … mailsync: null"* dialog (the exit `code` is `null` because the process was signalled). Clicking Rebuild doesn't help — the database was never the problem.

## Fix

Fall back to ad-hoc signing when no developer identity is available:

```sh
codesign -s "Mac Developer:" -f "${PROJECT_DIR}/../app/mailsync" 2>/dev/null || codesign -s - -f "${PROJECT_DIR}/../app/mailsync"
```

- Signing with a real identity is preserved when one is present, so there is no change for maintainers who have the cert.
- Ad-hoc (`-s -`) satisfies the Apple Silicon launch requirement so the binary runs for everyone else.
- This only affects **local development** runnability — release builds are re-signed by electron-osx-sign during packaging, so the distributed binary is unaffected either way.

## Testing

On an Apple Silicon machine with no "Mac Developer" identity: before this change, `xcodebuild -scheme mailsync -configuration Release` produced an unsigned `../app/mailsync` (`codesign -dv` → "code object is not signed at all") that was killed on launch. After this change, the build prints "Codesigned", `../app/mailsync` is ad-hoc signed (`codesign --verify --strict` passes), and it runs (`--mode migrate` → `{"error":null}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)