### PR TITLE
Fix cancellation of GetManyRFC2822Task (folder export)

### DIFF
--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -588,8 +588,18 @@ void TaskProcessor::performRemote(Task * task) {
                 logger->error("Unsure of how to process this task type {}", cname);
             }
 
-            logger->info("[{}] -- Succeeded. Changing status to `complete`", task->id());
-            task->setStatus("complete");
+            // A long-running task (e.g. GetManyRFC2822Task) can observe a
+            // cancel request while it runs and stop early, setting should_cancel
+            // on the task. Honor that here so it ends up "cancelled" rather than
+            // "complete"; the pre-run check above only covers cancels that
+            // arrive before the task starts.
+            if (task->shouldCancel()) {
+                logger->info("[{}] -- Cancelled. Changing status to `cancelled`", task->id());
+                task->setStatus("cancelled");
+            } else {
+                logger->info("[{}] -- Succeeded. Changing status to `complete`", task->id());
+                task->setStatus("complete");
+            }
         }
     } catch (SyncException & ex) {
         logger->error("[{}] -- Failed ({}). Changing status to `complete`", task->id(), ex.toJSON().dump());
@@ -2078,19 +2088,39 @@ void TaskProcessor::performRemoteGetManyRFC2822(Task * task) {
             globalIndex++;
         }
 
-        // After each chunk, save progress (including cursor) and check for cancellation
+        // After each chunk, persist progress and check for a cancel request in
+        // a single write transaction.
+        //
+        // Electron sets should_cancel on this same Task row from the main
+        // thread (TaskProcessor::cancel), using a different MailStore
+        // connection. Previously this code saved our in-memory task copy — in
+        // which should_cancel is false — and only then re-read the row, so the
+        // progress save clobbered a concurrently-set cancel flag and the
+        // re-read almost never saw it: once the export had started it could not
+        // be cancelled. Re-reading and saving inside one BEGIN IMMEDIATE
+        // transaction serializes against that cancel write, so a request is
+        // either already visible here or ordered strictly after our commit and
+        // seen on the next chunk — never lost.
         progress["exported"] = exported;
         progress["failed"] = failed;
         progress["lastUID"] = cursorUID;
-        task->data()["progress"] = progress;
-        store->save(task);
 
-        // Re-read task from DB to check for cancellation
-        auto refreshed = store->find<Task>(Query().equal("id", task->id()));
-        if (refreshed != nullptr && refreshed->shouldCancel()) {
-            progress["cancelled"] = true;
+        bool cancelled = false;
+        {
+            MailStoreTransaction transaction{store, "GetManyRFC2822 progress"};
+            auto refreshed = store->find<Task>(Query().equal("id", task->id()));
+            if (refreshed != nullptr && refreshed->shouldCancel()) {
+                cancelled = true;
+                progress["cancelled"] = true;
+                // Carry the flag onto our in-memory copy so this save preserves
+                // it and performRemote marks the task cancelled, not complete.
+                task->setShouldCancel();
+            }
             task->data()["progress"] = progress;
             store->save(task);
+            transaction.commit();
+        }
+        if (cancelled) {
             logger->info("GetManyRFC2822: cancelled after exporting {} of {} messages", exported, total);
             return;
         }


### PR DESCRIPTION
# Fix cancellation of GetManyRFC2822Task (folder export)

## Summary

A folder export (`GetManyRFC2822Task`) could not be cancelled once it had started, and an export that *was* cancelled ended up marked `complete` instead of `cancelled`. This fixes both. It also applies to the `.eml` folder export shipped in Foundry376/Mailspring#2652, which uses the same task and code path.

## Root cause

Two independent problems, both in `TaskProcessor`:

**1. The cancel flag was clobbered.** Electron requests cancellation by setting `should_cancel` on the `Task` row from the main thread (`TaskProcessor::cancel`), which runs on `runListenOnMainThread`'s own `MailStore` connection. The export runs on the `SyncWorker` thread with a *different* `MailStore` connection. Every chunk, the export loop saved its in-memory task copy — in which `should_cancel` is `false` — and only *then* re-read the row to check for cancellation:

```cpp
task->data()["progress"] = progress;
store->save(task);                              // clobbers a just-set should_cancel
auto refreshed = store->find<Task>(...);        // re-read almost always sees false
if (refreshed != nullptr && refreshed->shouldCancel()) { ... }
```

So the progress save overwrote any `should_cancel` the main thread had set, and the check only ever succeeded in the microscopic window where the cancel committed between our save and our re-read. In practice the export always ran to completion.

**2. The final status was always `complete`.** `performRemote` checks `should_cancel` only *before* running a task, then unconditionally sets `complete` afterward. A task cancelled mid-run therefore finished as `complete` (with `progress.cancelled` set), never `cancelled`.

## The fix

**Serialize the progress save with the cancel check.** The two now happen inside one `BEGIN IMMEDIATE` transaction:

```cpp
bool cancelled = false;
{
    MailStoreTransaction transaction{store, "GetManyRFC2822 progress"};
    auto refreshed = store->find<Task>(Query().equal("id", task->id()));
    if (refreshed != nullptr && refreshed->shouldCancel()) {
        cancelled = true;
        progress["cancelled"] = true;
        task->setShouldCancel();   // preserve across the save; signal performRemote
    }
    task->data()["progress"] = progress;
    store->save(task);
    transaction.commit();
}
if (cancelled) { ...; return; }
```

Because SQLite (WAL) serializes writers, the worker's transaction and the main thread's `cancel` transaction cannot interleave: the cancel is either already committed when the worker reads, or ordered strictly after the worker's commit and observed on the next chunk. The flag can no longer be lost, and reading the fresh row is what makes the cross-connection request visible.

**Honor a mid-run cancel in the final status.** `performRemote` now re-checks `should_cancel` after the task returns (the loop above carries it forward), and marks the task `cancelled` rather than `complete`:

```cpp
if (task->shouldCancel()) {
    task->setStatus("cancelled");
} else {
    task->setStatus("complete");
}
```

The pre-run check for cancels that arrive before a task starts is unchanged. No new columns, migrations, or schema changes.

## Testing

Built on macOS (Xcode, Release) and tested against a live account: started a large folder export, cancelled it partway through, and confirmed the export stops promptly at the next chunk boundary and the task ends up `cancelled` (previously it ran to completion and reported `complete`).
