### PR TITLE
Fall back to legacy TLS settings when the handshake is rejected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ CMakeCache.txt
 CMakeFiles/
 Makefile
 cmake_install.cmake
+/mailsync
+/Vendor/mailcore2/build/

--- a/MailSync/MailUtils.cpp
+++ b/MailSync/MailUtils.cpp
@@ -799,6 +799,9 @@ void MailUtils::configureSessionForAccount(IMAPSession &session, shared_ptr<Acco
     }
     if (account->IMAPAllowInsecureSSL()) {
         session.setCheckCertificateEnabled(false);
+        // Also let the handshake itself fall back to OpenSSL security level 0,
+        // for servers still using SHA-1 certificates or undersized DH groups.
+        session.setObsoleteTLSAllowed(true);
     }
 
     // iCloud's QRESYNC implementation has known issues: it returns malformed VANISHED
@@ -840,6 +843,7 @@ void MailUtils::configureSessionForAccount(SMTPSession & session, shared_ptr<Acc
     }
     if (account->SMTPAllowInsecureSSL()) {
         session.setCheckCertificateEnabled(false);
+        session.setObsoleteTLSAllowed(true);
     }
 
     if (_verboseLogging) {

--- a/MailSync/MailUtils.cpp
+++ b/MailSync/MailUtils.cpp
@@ -778,8 +778,18 @@ class MailcoreSPDLogger : public ConnectionLogger {
     }
 };
 
-string MailUtils::tlsFailureAdvice(mailcore::String * tlsErrorDescription, bool obsoleteTLSAllowed) {
+string MailUtils::tlsFailureAdvice(mailcore::ErrorCode err, mailcore::String * tlsErrorDescription, bool obsoleteTLSAllowed) {
     if (tlsErrorDescription == nullptr) {
+        return "";
+    }
+
+    // Only speak up when establishing the connection is what failed. Anything
+    // later - authentication above all - has its own cause, and a handshake
+    // reason recorded during a successful fallback would be a red herring.
+    if (err != mailcore::ErrorConnection &&
+        err != mailcore::ErrorTLSNotAvailable &&
+        err != mailcore::ErrorStartTLSNotAvailable &&
+        err != mailcore::ErrorCertificate) {
         return "";
     }
 

--- a/MailSync/MailUtils.cpp
+++ b/MailSync/MailUtils.cpp
@@ -778,6 +778,29 @@ class MailcoreSPDLogger : public ConnectionLogger {
     }
 };
 
+string MailUtils::tlsFailureAdvice(mailcore::String * tlsErrorDescription, bool obsoleteTLSAllowed) {
+    if (tlsErrorDescription == nullptr) {
+        return "";
+    }
+
+    // OpenSSL reports "error:0A00018A:SSL routines::dh key too small". Only the
+    // reason after the last "::" is worth showing; the full string stays in the
+    // connection log.
+    string reason = tlsErrorDescription->UTF8Characters();
+    size_t sep = reason.rfind("::");
+    if (sep != string::npos && sep + 2 < reason.size()) {
+        reason = reason.substr(sep + 2);
+    }
+
+    string advice = "The server rejected the secure connection (" + reason + "). ";
+    advice += "This server uses outdated encryption.";
+
+    if (!obsoleteTLSAllowed) {
+        advice += " Enabling \"Allow insecure SSL\" in this account's settings may allow Mailspring to connect.";
+    }
+    return advice;
+}
+
 void MailUtils::configureSessionForAccount(IMAPSession &session, shared_ptr<Account> account) {
     if (account->refreshToken() != "") {
         XOAuth2Parts parts = SharedXOAuth2TokenManager()->partsForAccount(account);

--- a/MailSync/MailUtils.hpp
+++ b/MailSync/MailUtils.hpp
@@ -91,10 +91,17 @@ public:
     // the server offers a DH group or certificate that OpenSSL rejects. When the
     // account has not enabled "Allow insecure SSL", the advice mentions it,
     // because that is what lets the connection fall back far enough to succeed.
-    // Returns an empty string when the failure was not a TLS rejection, so it
-    // can be appended unconditionally.
-    // Pass session.lastTLSErrorDescription() and session.isObsoleteTLSAllowed().
-    static string tlsFailureAdvice(mailcore::String * tlsErrorDescription, bool obsoleteTLSAllowed);
+    //
+    // Returns an empty string unless `err` says the connection itself failed, so
+    // it can be appended unconditionally. That check belongs here rather than in
+    // the caller: a recorded reason outlives a successful fallback by design, so
+    // callers that bundle connect with a later step - SMTPSession::loginIfNeeded
+    // bundles it with authentication - would otherwise blame outdated encryption
+    // for a wrong password.
+    //
+    // Pass the error from the call, session.lastTLSErrorDescription() and
+    // session.isObsoleteTLSAllowed().
+    static string tlsFailureAdvice(mailcore::ErrorCode err, mailcore::String * tlsErrorDescription, bool obsoleteTLSAllowed);
     
     static IMAPMessagesRequestKind messagesRequestKindFor(IndexSet * capabilities, bool heavyOrNeedToComputeIDs);
 

--- a/MailSync/MailUtils.hpp
+++ b/MailSync/MailUtils.hpp
@@ -86,6 +86,15 @@ public:
     static void enableVerboseLogging();
     static void configureSessionForAccount(IMAPSession & session, shared_ptr<Account> account);
     static void configureSessionForAccount(SMTPSession & session, shared_ptr<Account> account);
+
+    // Explains a connection that failed during the TLS handshake, e.g. because
+    // the server offers a DH group or certificate that OpenSSL rejects. When the
+    // account has not enabled "Allow insecure SSL", the advice mentions it,
+    // because that is what lets the connection fall back far enough to succeed.
+    // Returns an empty string when the failure was not a TLS rejection, so it
+    // can be appended unconditionally.
+    // Pass session.lastTLSErrorDescription() and session.isObsoleteTLSAllowed().
+    static string tlsFailureAdvice(mailcore::String * tlsErrorDescription, bool obsoleteTLSAllowed);
     
     static IMAPMessagesRequestKind messagesRequestKindFor(IndexSet * capabilities, bool heavyOrNeedToComputeIDs);
 

--- a/MailSync/SyncWorker.cpp
+++ b/MailSync/SyncWorker.cpp
@@ -137,6 +137,11 @@ void SyncWorker::idleCycleIteration()
     ErrorCode err = ErrorCode::ErrorNone;
     session.connectIfNeeded(&err);
     if (err != ErrorCode::ErrorNone) {
+        string advice = MailUtils::tlsFailureAdvice(session.lastTLSErrorDescription(), session.isObsoleteTLSAllowed());
+        if (advice != "") {
+            logger->error("{}", advice);
+            throw SyncException(err, "connectIfNeeded: " + advice);
+        }
         throw SyncException(err, "connectIfNeeded");
     }
     

--- a/MailSync/SyncWorker.cpp
+++ b/MailSync/SyncWorker.cpp
@@ -137,7 +137,7 @@ void SyncWorker::idleCycleIteration()
     ErrorCode err = ErrorCode::ErrorNone;
     session.connectIfNeeded(&err);
     if (err != ErrorCode::ErrorNone) {
-        string advice = MailUtils::tlsFailureAdvice(session.lastTLSErrorDescription(), session.isObsoleteTLSAllowed());
+        string advice = MailUtils::tlsFailureAdvice(err, session.lastTLSErrorDescription(), session.isObsoleteTLSAllowed());
         if (advice != "") {
             logger->error("{}", advice);
             throw SyncException(err, "connectIfNeeded: " + advice);

--- a/MailSync/main.cpp
+++ b/MailSync/main.cpp
@@ -294,6 +294,7 @@ int runTestAuth(shared_ptr<Account> account) {
     ErrorCode err = ErrorNone;
     Address * from = Address::addressWithMailbox(AS_MCSTR(account->emailAddress()));
     string errorService = "imap";
+    string tlsAdvice = "";
     string containerFolderPath = account->containerFolder();
     string mainPrefix = "";
     
@@ -304,6 +305,10 @@ int runTestAuth(shared_ptr<Account> account) {
     session.setConnectionLogger(&alogger);
     session.connect(&err);
     if (err != ErrorNone) {
+        tlsAdvice = MailUtils::tlsFailureAdvice(session.lastTLSErrorDescription(), session.isObsoleteTLSAllowed());
+        if (tlsAdvice != "") {
+            alogger.log("\n\n" + tlsAdvice + "\n");
+        }
         goto done;
     }
     folders = session.fetchAllFolders(&err);
@@ -350,6 +355,10 @@ int runTestAuth(shared_ptr<Account> account) {
         smtp.checkAccount(from, &err);
     }
     if (err != ErrorNone) {
+        tlsAdvice = MailUtils::tlsFailureAdvice(smtp.lastTLSErrorDescription(), smtp.isObsoleteTLSAllowed());
+        if (tlsAdvice != "") {
+            alogger.log("\n\n" + tlsAdvice + "\n");
+        }
         alogger.log("\n\nSASL_PATH: " + MailUtils::getEnvUTF8("SASL_PATH"));
 
         if (smtp.lastSMTPResponse()) {
@@ -381,6 +390,9 @@ done:
         return 0;
     } else {
         resp["error"] = ErrorCodeToTypeMap.count(err) ? ErrorCodeToTypeMap[err] : "Unknown";
+        if (tlsAdvice != "") {
+            resp["error_advice"] = tlsAdvice;
+        }
         cout << resp.dump();
         return 1;
     }

--- a/MailSync/main.cpp
+++ b/MailSync/main.cpp
@@ -546,10 +546,12 @@ int runInstallCheck() {
     }
 
     // Step 3b: Check TLS against a server that still uses legacy encryption.
-    // imap.shaw.ca negotiates parameters that Apple's Security.framework
-    // accepts but that modern OpenSSL rejects out of the box, so this check is
-    // expected to pass on macOS and fail on the OpenSSL platforms (Windows,
-    // Linux) until the connection code learns to fall back.
+    // imap.shaw.ca offers a DH group that modern OpenSSL rejects ("dh key too
+    // small") while Apple's Security.framework accepts it, which is why the
+    // account works on macOS and fails on Windows and Linux. This exercises the
+    // compatibility fallback in IMAPSession::connect and reports the level it
+    // settled on, so a server needing the obsolete tier is visible rather than
+    // silently absorbed.
     string legacyTLSError = "";
     alogger.log("\n\n----------LEGACY TLS----------\n");
     try {
@@ -558,13 +560,27 @@ int runInstallCheck() {
         session.setPort(993);
         session.setConnectionType(ConnectionType::ConnectionTypeTLS);
         session.setConnectionLogger(&alogger);
-        // No username/password - we just want to verify the handshake works
+        // Exercise the whole ladder. Real accounts only reach the obsolete tier
+        // when the user has enabled "Allow insecure SSL".
+        session.setObsoleteTLSAllowed(true);
 
         ErrorCode err = ErrorNone;
         session.connect(&err);
 
-        if (err != ErrorNone && err != ErrorAuthentication && err != ErrorAuthenticationRequired) {
-            legacyTLSError = ErrorCodeToTypeMap.count(err) ? ErrorCodeToTypeMap[err] : ("legacy TLS error code: " + to_string(err));
+        int level = session.tlsCompatibilityLevel();
+
+        if (err == ErrorNone || err == ErrorAuthentication || err == ErrorAuthenticationRequired) {
+            alogger.log("\nConnected at TLS compatibility level " + to_string(level) + "\n");
+            resp["legacy_tls_check"] = {{"success", true}, {"compatibility_level", level}};
+        } else if (session.lastTLSErrorDescription() != NULL) {
+            // The handshake itself was rejected at every level - the fallback
+            // is not doing its job. That is the regression this check catches.
+            legacyTLSError = string("TLS handshake rejected: ") + session.lastTLSErrorDescription()->UTF8Characters();
+        } else {
+            // Unreachable, refused or timed out. That is the server or the
+            // network rather than our TLS configuration, so don't fail here.
+            alogger.log("\nimap.shaw.ca unreachable, skipping legacy TLS check\n");
+            resp["legacy_tls_check"] = {{"skipped", "host unreachable"}};
         }
         session.disconnect();
     } catch (std::exception & ex) {
@@ -573,8 +589,6 @@ int runInstallCheck() {
 
     if (legacyTLSError != "") {
         resp["legacy_tls_check"] = {{"error", legacyTLSError}};
-    } else {
-        resp["legacy_tls_check"] = {{"success", true}};
     }
 
     // Step 4: Check libtidy by actually processing HTML (Linux only)

--- a/MailSync/main.cpp
+++ b/MailSync/main.cpp
@@ -413,6 +413,7 @@ int runInstallCheck() {
         {"imap_check", nullptr},
         {"smtp_check", nullptr},
         {"tidy_check", nullptr},
+        {"legacy_tls_check", nullptr},
         {"log", nullptr}
     };
 
@@ -544,6 +545,38 @@ int runInstallCheck() {
         resp["smtp_check"] = {{"success", true}};
     }
 
+    // Step 3b: Check TLS against a server that still uses legacy encryption.
+    // imap.shaw.ca negotiates parameters that Apple's Security.framework
+    // accepts but that modern OpenSSL rejects out of the box, so this check is
+    // expected to pass on macOS and fail on the OpenSSL platforms (Windows,
+    // Linux) until the connection code learns to fall back.
+    string legacyTLSError = "";
+    alogger.log("\n\n----------LEGACY TLS----------\n");
+    try {
+        IMAPSession session;
+        session.setHostname(MCSTR("imap.shaw.ca"));
+        session.setPort(993);
+        session.setConnectionType(ConnectionType::ConnectionTypeTLS);
+        session.setConnectionLogger(&alogger);
+        // No username/password - we just want to verify the handshake works
+
+        ErrorCode err = ErrorNone;
+        session.connect(&err);
+
+        if (err != ErrorNone && err != ErrorAuthentication && err != ErrorAuthenticationRequired) {
+            legacyTLSError = ErrorCodeToTypeMap.count(err) ? ErrorCodeToTypeMap[err] : ("legacy TLS error code: " + to_string(err));
+        }
+        session.disconnect();
+    } catch (std::exception & ex) {
+        legacyTLSError = ex.what();
+    }
+
+    if (legacyTLSError != "") {
+        resp["legacy_tls_check"] = {{"error", legacyTLSError}};
+    } else {
+        resp["legacy_tls_check"] = {{"success", true}};
+    }
+
     // Step 4: Check libtidy by actually processing HTML (Linux only)
     string tidyError = "";
 #if defined(__linux__)
@@ -605,7 +638,7 @@ int runInstallCheck() {
     }
 
     // Determine overall success
-    bool success = (httpError == "" && imapError == "" && smtpError == "" && tidyError == "");
+    bool success = (httpError == "" && imapError == "" && smtpError == "" && tidyError == "" && legacyTLSError == "");
     if (!success) {
         resp["error"] = "One or more checks failed";
     }

--- a/MailSync/main.cpp
+++ b/MailSync/main.cpp
@@ -305,7 +305,7 @@ int runTestAuth(shared_ptr<Account> account) {
     session.setConnectionLogger(&alogger);
     session.connect(&err);
     if (err != ErrorNone) {
-        tlsAdvice = MailUtils::tlsFailureAdvice(session.lastTLSErrorDescription(), session.isObsoleteTLSAllowed());
+        tlsAdvice = MailUtils::tlsFailureAdvice(err, session.lastTLSErrorDescription(), session.isObsoleteTLSAllowed());
         if (tlsAdvice != "") {
             alogger.log("\n\n" + tlsAdvice + "\n");
         }
@@ -355,7 +355,7 @@ int runTestAuth(shared_ptr<Account> account) {
         smtp.checkAccount(from, &err);
     }
     if (err != ErrorNone) {
-        tlsAdvice = MailUtils::tlsFailureAdvice(smtp.lastTLSErrorDescription(), smtp.isObsoleteTLSAllowed());
+        tlsAdvice = MailUtils::tlsFailureAdvice(err, smtp.lastTLSErrorDescription(), smtp.isObsoleteTLSAllowed());
         if (tlsAdvice != "") {
             alogger.log("\n\n" + tlsAdvice + "\n");
         }

--- a/Vendor/libetpan/src/data-types/mailstream_ssl.c
+++ b/Vendor/libetpan/src/data-types/mailstream_ssl.c
@@ -109,6 +109,33 @@
 #include "mmapstring.h"
 #include "mailstream_cancel.h"
 
+/* Thread-local description of the last TLS handshake failure. Handshakes for
+   different accounts run on different threads, so this must not be shared. */
+#ifdef WIN32
+#define MAILSTREAM_THREAD_LOCAL __declspec(thread)
+#else
+#define MAILSTREAM_THREAD_LOCAL __thread
+#endif
+
+static MAILSTREAM_THREAD_LOCAL char mailstream_ssl_last_error[256] = { 0 };
+static MAILSTREAM_THREAD_LOCAL int mailstream_ssl_last_error_set = 0;
+
+const char * mailstream_ssl_get_last_error(void)
+{
+  return mailstream_ssl_last_error;
+}
+
+int mailstream_ssl_has_last_error(void)
+{
+  return mailstream_ssl_last_error_set;
+}
+
+static void mailstream_ssl_clear_last_error(void)
+{
+  mailstream_ssl_last_error[0] = '\0';
+  mailstream_ssl_last_error_set = 0;
+}
+
 struct mailstream_ssl_context
 {
   int fd;
@@ -468,6 +495,8 @@ static struct mailstream_ssl_data * ssl_data_new_full(int fd, time_t timeout,
 #endif
 
   mailstream_ssl_init();
+  mailstream_ssl_clear_last_error();
+  ERR_clear_error();
 
   tmp_ctx = SSL_CTX_new(method);
   if (tmp_ctx == NULL) {
@@ -535,17 +564,22 @@ again:
   if (r <= 0) {
     unsigned long ssl_err = ERR_get_error();
     if (ssl_err != 0) {
-      char err_buf[256];
-      ERR_error_string_n(ssl_err, err_buf, sizeof(err_buf));
-      fprintf(stderr, "SSL_connect failed: %s\n", err_buf);
-      /* Log additional errors in the queue */
-      while ((ssl_err = ERR_get_error()) != 0) {
-        ERR_error_string_n(ssl_err, err_buf, sizeof(err_buf));
-        fprintf(stderr, "SSL error: %s\n", err_buf);
-      }
+      /* Record the first (most specific) reason so the caller can report
+         "dh key too small" rather than an opaque error code, and can decide
+         whether retrying at a lower compatibility level is worthwhile. */
+      ERR_error_string_n(ssl_err, mailstream_ssl_last_error,
+        sizeof(mailstream_ssl_last_error));
+      mailstream_ssl_last_error_set = 1;
+      ERR_clear_error();
     } else {
       int ssl_error = SSL_get_error(ssl_conn, r);
-      fprintf(stderr, "SSL_connect failed with SSL_ERROR: %d\n", ssl_error);
+      snprintf(mailstream_ssl_last_error, sizeof(mailstream_ssl_last_error),
+        "SSL_connect failed with SSL_ERROR %d", ssl_error);
+      /* SSL_ERROR_SYSCALL / SSL_ERROR_ZERO_RETURN with an empty error queue
+         means the peer went away rather than rejecting our parameters, so it
+         is not treated as a negotiation failure. */
+      mailstream_ssl_last_error_set =
+        (ssl_error != SSL_ERROR_SYSCALL) && (ssl_error != SSL_ERROR_ZERO_RETURN);
     }
     goto free_ssl_conn;
   }
@@ -639,7 +673,8 @@ static struct mailstream_ssl_data * ssl_data_new(int fd, time_t timeout,
   unsigned int timeout_value;
   
   mailstream_ssl_init();
-  
+  mailstream_ssl_clear_last_error();
+
   if (gnutls_certificate_allocate_credentials (&xcred) != 0)
     return NULL;
 
@@ -1521,6 +1556,48 @@ void * mailstream_ssl_get_openssl_ssl_ctx(struct mailstream_ssl_context * ssl_co
 int mailstream_ssl_get_fd(struct mailstream_ssl_context * ssl_context)
 {
   return ssl_context->fd;
+}
+
+int mailstream_ssl_set_compatibility_level(struct mailstream_ssl_context * ssl_context,
+    int level)
+{
+#if defined(USE_SSL) && !defined(USE_GNUTLS)
+  SSL_CTX * ctx;
+
+  if (ssl_context == NULL)
+    return -1;
+
+  ctx = ssl_context->openssl_ssl_ctx;
+  if (ctx == NULL)
+    return -1;
+
+  if (level == MAILSTREAM_SSL_COMPAT_DEFAULT)
+    return 0;
+
+  /* Old servers predate RFC 5746. OpenSSL 3 refuses them by default; allowing
+     the initial handshake does not allow unsafe renegotiation afterwards. */
+  SSL_CTX_set_options(ctx, SSL_OP_LEGACY_SERVER_CONNECT);
+
+#ifdef SSL_CTX_set_min_proto_version
+  SSL_CTX_set_min_proto_version(ctx, TLS1_VERSION);
+#endif
+
+  if (level >= MAILSTREAM_SSL_COMPAT_OBSOLETE) {
+    SSL_CTX_set_security_level(ctx, 0);
+    SSL_CTX_set_cipher_list(ctx, "ALL:@SECLEVEL=0");
+  }
+  else {
+    SSL_CTX_set_security_level(ctx, 1);
+    SSL_CTX_set_cipher_list(ctx, "DEFAULT:@SECLEVEL=1");
+  }
+
+  return 0;
+#else
+  /* CFStream and GnuTLS builds negotiate legacy servers without help. */
+  (void) ssl_context;
+  (void) level;
+  return 0;
+#endif
 }
 
 static struct mailstream_cancel * mailstream_low_ssl_get_cancel(mailstream_low * s)

--- a/Vendor/libetpan/src/data-types/mailstream_ssl.c
+++ b/Vendor/libetpan/src/data-types/mailstream_ssl.c
@@ -130,7 +130,7 @@ int mailstream_ssl_has_last_error(void)
   return mailstream_ssl_last_error_set;
 }
 
-static void mailstream_ssl_clear_last_error(void)
+void mailstream_ssl_clear_last_error(void)
 {
   mailstream_ssl_last_error[0] = '\0';
   mailstream_ssl_last_error_set = 0;

--- a/Vendor/libetpan/src/data-types/mailstream_ssl.h
+++ b/Vendor/libetpan/src/data-types/mailstream_ssl.h
@@ -179,6 +179,16 @@ const char * mailstream_ssl_get_last_error(void);
 LIBETPAN_EXPORT
 int mailstream_ssl_has_last_error(void);
 
+/*
+  Forget any recorded failure on the calling thread. The handshake itself
+  resets this, but only once it is reached: a connection that fails earlier, at
+  the TCP level, leaves the previous handshake's reason in place. Callers that
+  ask about a specific attempt must clear this before making it, or a stale
+  reason will be read as belonging to the new attempt.
+*/
+LIBETPAN_EXPORT
+void mailstream_ssl_clear_last_error(void);
+
 LIBETPAN_EXPORT
 int mailstream_ssl_get_fd(struct mailstream_ssl_context * ssl_context);
 

--- a/Vendor/libetpan/src/data-types/mailstream_ssl.h
+++ b/Vendor/libetpan/src/data-types/mailstream_ssl.h
@@ -130,6 +130,55 @@ int mailstream_ssl_set_server_name(struct mailstream_ssl_context * ssl_context,
 LIBETPAN_EXPORT
 void * mailstream_ssl_get_openssl_ssl_ctx(struct mailstream_ssl_context * ssl_context);
 
+/*
+  TLS compatibility levels.
+
+  Modern OpenSSL refuses a number of handshakes that older mail servers still
+  require. Apple's Security.framework (used through CFStream) is considerably
+  more permissive, which is why such servers often work on macOS but fail on
+  Windows and Linux with a bare "SSL error". These levels let a caller retry a
+  failed handshake with progressively relaxed settings.
+
+  MAILSTREAM_SSL_COMPAT_DEFAULT   - OpenSSL defaults, nothing relaxed.
+  MAILSTREAM_SSL_COMPAT_LEGACY    - allow servers without RFC 5746 secure
+                                    renegotiation, allow TLS 1.0/1.1, and pin
+                                    the security level to OpenSSL's own default
+                                    of 1 (distributions such as Debian ship a
+                                    build defaulting to 2). Still requires 80
+                                    bits of security.
+  MAILSTREAM_SSL_COMPAT_OBSOLETE  - security level 0. Additionally permits
+                                    SHA-1 signed certificates, RSA keys below
+                                    2048 bits and small DH parameters. This
+                                    waives checks a mail client should not
+                                    waive without the user's consent.
+*/
+#define MAILSTREAM_SSL_COMPAT_DEFAULT  0
+#define MAILSTREAM_SSL_COMPAT_LEGACY   1
+#define MAILSTREAM_SSL_COMPAT_OBSOLETE 2
+
+LIBETPAN_EXPORT
+int mailstream_ssl_set_compatibility_level(struct mailstream_ssl_context * ssl_context,
+    int level);
+
+/*
+  Description of the last TLS handshake failure on the calling thread, as
+  reported by the TLS backend (for example "dh key too small"). Returns an
+  empty string when the last handshake did not fail or when the backend does
+  not report a reason. The storage is thread-local and is reset at the start of
+  every handshake.
+*/
+LIBETPAN_EXPORT
+const char * mailstream_ssl_get_last_error(void);
+
+/*
+  Non-zero when the last handshake on the calling thread failed inside the TLS
+  backend rather than at the socket level. Callers use this to tell a TLS
+  negotiation failure (worth retrying at a lower compatibility level) from an
+  unreachable host.
+*/
+LIBETPAN_EXPORT
+int mailstream_ssl_has_last_error(void);
+
 LIBETPAN_EXPORT
 int mailstream_ssl_get_fd(struct mailstream_ssl_context * ssl_context);
 

--- a/Vendor/mailcore2/src/core/imap/MCIMAPSession.cpp
+++ b/Vendor/mailcore2/src/core/imap/MCIMAPSession.cpp
@@ -735,6 +735,10 @@ void IMAPSession::connect(ErrorCode * pError)
         if (!mailstream_ssl_has_last_error()) {
             // Not a negotiation failure - the host is unreachable, refused the
             // connection or dropped it. Retrying with weaker crypto cannot help.
+            // Drop any reason recorded at an earlier level so callers don't
+            // report a stale rejection for a failure that wasn't one. It stays
+            // in the log either way.
+            MC_SAFE_RELEASE(mLastTLSErrorDescription);
             return;
         }
 

--- a/Vendor/mailcore2/src/core/imap/MCIMAPSession.cpp
+++ b/Vendor/mailcore2/src/core/imap/MCIMAPSession.cpp
@@ -377,6 +377,9 @@ void IMAPSession::init()
     mAuthType = AuthTypeSASLNone;
     mConnectionType = ConnectionTypeClear;
     mCheckCertificateEnabled = true;
+    mObsoleteTLSAllowed = false;
+    mTLSCompatibilityLevel = MAILSTREAM_SSL_COMPAT_DEFAULT;
+    mLastTLSErrorDescription = NULL;
     mVoIPEnabled = true;
     mDelimiter = 0;
     
@@ -446,6 +449,7 @@ IMAPSession::~IMAPSession()
     MC_SAFE_RELEASE(mWelcomeString);
     MC_SAFE_RELEASE(mDefaultNamespace);
     MC_SAFE_RELEASE(mCurrentFolder);
+    MC_SAFE_RELEASE(mLastTLSErrorDescription);
     pthread_mutex_destroy(&mIdleLock);
     pthread_mutex_destroy(&mConnectionLoggerLock);
 }
@@ -538,6 +542,26 @@ void IMAPSession::setCheckCertificateEnabled(bool enabled)
 bool IMAPSession::isCheckCertificateEnabled()
 {
     return mCheckCertificateEnabled;
+}
+
+void IMAPSession::setObsoleteTLSAllowed(bool allowed)
+{
+    mObsoleteTLSAllowed = allowed;
+}
+
+bool IMAPSession::isObsoleteTLSAllowed()
+{
+    return mObsoleteTLSAllowed;
+}
+
+String * IMAPSession::lastTLSErrorDescription()
+{
+    return mLastTLSErrorDescription;
+}
+
+int IMAPSession::tlsCompatibilityLevel()
+{
+    return mTLSCompatibilityLevel;
 }
 
 void IMAPSession::setVoIPEnabled(bool enabled)
@@ -636,12 +660,15 @@ static bool isIPAddress(const char * hostname)
 
 static void ssl_callback(struct mailstream_ssl_context * ssl_context, void * data)
 {
+    IMAPSession * session = (IMAPSession *) data;
+
     // Set the Server Name Indication (SNI) for TLS connections
     // SNI only makes sense for hostnames, not IP addresses
-    const char * hostname = (const char *) data;
+    const char * hostname = session->hostname() != NULL ? MCUTF8(session->hostname()) : NULL;
     if (hostname != NULL && !isIPAddress(hostname)) {
         mailstream_ssl_set_server_name(ssl_context, (char *) hostname);
     }
+    mailstream_ssl_set_compatibility_level(ssl_context, session->mTLSCompatibilityLevel);
 }
 
 void IMAPSession::setup()
@@ -678,8 +705,56 @@ void IMAPSession::unsetup()
 
 void IMAPSession::connect(ErrorCode * pError)
 {
+    MC_SAFE_RELEASE(mLastTLSErrorDescription);
+
+    if (mConnectionType == ConnectionTypeClear) {
+        mTLSCompatibilityLevel = MAILSTREAM_SSL_COMPAT_DEFAULT;
+        connectWithCurrentCompatibilityLevel(pError);
+        return;
+    }
+
+    // Modern OpenSSL rejects handshakes that older mail servers still require,
+    // while Apple's Security.framework accepts them - which is why such servers
+    // work on macOS and fail elsewhere. Start strict and relax only after the
+    // backend itself rejected the negotiation, so a healthy server is never
+    // downgraded and an unreachable one is not retried pointlessly.
+    int maxLevel = mObsoleteTLSAllowed ? MAILSTREAM_SSL_COMPAT_OBSOLETE : MAILSTREAM_SSL_COMPAT_LEGACY;
+
+    for (int level = MAILSTREAM_SSL_COMPAT_DEFAULT; level <= maxLevel; level++) {
+        mTLSCompatibilityLevel = level;
+        connectWithCurrentCompatibilityLevel(pError);
+
+        if (* pError == ErrorNone) {
+            if (level != MAILSTREAM_SSL_COMPAT_DEFAULT) {
+                MCLog("%s uses outdated encryption, connected at TLS compatibility level %i",
+                      MCUTF8(mHostname), level);
+            }
+            return;
+        }
+
+        if (!mailstream_ssl_has_last_error()) {
+            // Not a negotiation failure - the host is unreachable, refused the
+            // connection or dropped it. Retrying with weaker crypto cannot help.
+            return;
+        }
+
+        MC_SAFE_REPLACE_RETAIN(String, mLastTLSErrorDescription,
+                               String::stringWithUTF8Characters(mailstream_ssl_get_last_error()));
+
+        MCLog("TLS handshake with %s rejected at compatibility level %i: %s",
+              MCUTF8(mHostname), level, mailstream_ssl_get_last_error());
+    }
+
+    if (!mObsoleteTLSAllowed) {
+        MCLog("%s requires obsolete TLS. Enable \"Allow insecure SSL\" for this account to connect anyway.",
+              MCUTF8(mHostname));
+    }
+}
+
+void IMAPSession::connectWithCurrentCompatibilityLevel(ErrorCode * pError)
+{
     int r;
-    
+
     setup();
 
     MCLog("connect %s", MCUTF8DESC(this));
@@ -700,9 +775,9 @@ void IMAPSession::connect(ErrorCode * pError)
             goto close;
         }
 
-        r = mailimap_socket_starttls_with_callback(mImap, ssl_callback, (void *) MCUTF8(mHostname));
+        r = mailimap_socket_starttls_with_callback(mImap, ssl_callback, this);
         if (hasError(r)) {
-            MCLog("no TLS %i", r);
+            MCLog("no TLS %i (%s)", r, mailstream_ssl_get_last_error());
             * pError = ErrorTLSNotAvailable;
             goto close;
         }
@@ -716,10 +791,10 @@ void IMAPSession::connect(ErrorCode * pError)
 
         case ConnectionTypeTLS:
         r = mailimap_ssl_connect_voip_with_callback(mImap, MCUTF8(mHostname), mPort, isVoIPEnabled(),
-            ssl_callback, (void *) MCUTF8(mHostname));
+            ssl_callback, this);
         MCLog("TLS ssl connect %s %u %u", MCUTF8(mHostname), mPort, r);
         if (hasError(r)) {
-            MCLog("connect error %i", r);
+            MCLog("connect error %i (%s)", r, mailstream_ssl_get_last_error());
             * pError = ErrorConnection;
             goto close;
         }

--- a/Vendor/mailcore2/src/core/imap/MCIMAPSession.cpp
+++ b/Vendor/mailcore2/src/core/imap/MCIMAPSession.cpp
@@ -759,6 +759,11 @@ void IMAPSession::connectWithCurrentCompatibilityLevel(ErrorCode * pError)
 {
     int r;
 
+    // The handshake resets this, but a connection that fails before reaching it
+    // would otherwise leave the previous attempt's reason in place, and the
+    // caller would read it as belonging to this one.
+    mailstream_ssl_clear_last_error();
+
     setup();
 
     MCLog("connect %s", MCUTF8DESC(this));

--- a/Vendor/mailcore2/src/core/imap/MCIMAPSession.h
+++ b/Vendor/mailcore2/src/core/imap/MCIMAPSession.h
@@ -56,7 +56,22 @@ namespace mailcore {
         
         virtual void setCheckCertificateEnabled(bool enabled);
         virtual bool isCheckCertificateEnabled();
-        
+
+        // When enabled, a TLS handshake that fails at every safer setting is
+        // retried with OpenSSL's security level 0, which permits SHA-1 signed
+        // certificates and undersized RSA/DH parameters. Off by default.
+        virtual void setObsoleteTLSAllowed(bool allowed);
+        virtual bool isObsoleteTLSAllowed();
+
+        // Reason reported by the TLS backend for the last failed handshake,
+        // e.g. "dh key too small". NULL when the last connect did not fail
+        // during the handshake.
+        virtual String * lastTLSErrorDescription();
+
+        // Compatibility level the last connect() settled on. See
+        // MAILSTREAM_SSL_COMPAT_* in libetpan's mailstream_ssl.h.
+        virtual int tlsCompatibilityLevel();
+
         virtual void setVoIPEnabled(bool enabled);
         virtual bool isVoIPEnabled();
         
@@ -245,6 +260,9 @@ namespace mailcore {
         virtual void unlockConnectionLogger();
         virtual ConnectionLogger * connectionLoggerNoLock();
 
+        // Read by the TLS handshake callback, which is a plain C callback.
+        int mTLSCompatibilityLevel;
+
     private:
         String * mHostname;
         unsigned int mPort;
@@ -254,6 +272,8 @@ namespace mailcore {
         AuthType mAuthType;
         ConnectionType mConnectionType;
         bool mCheckCertificateEnabled;
+        bool mObsoleteTLSAllowed;
+        String * mLastTLSErrorDescription;
         bool mVoIPEnabled;
         char mDelimiter;
         IMAPNamespace * mDefaultNamespace;
@@ -313,6 +333,7 @@ namespace mailcore {
         static void items_progress(size_t current, size_t maximum, void * context);
         void setup();
         void unsetup();
+        void connectWithCurrentCompatibilityLevel(ErrorCode * pError);
         char fetchDelimiterIfNeeded(char defaultDelimiter, ErrorCode * pError);
         IMAPSyncResult * fetchMessages(String * folder, IMAPMessagesRequestKind requestKind,
                                        bool fetchByUID, struct mailimap_set * imapset,

--- a/Vendor/mailcore2/src/core/imap/MCIMAPSession.h
+++ b/Vendor/mailcore2/src/core/imap/MCIMAPSession.h
@@ -63,9 +63,11 @@ namespace mailcore {
         virtual void setObsoleteTLSAllowed(bool allowed);
         virtual bool isObsoleteTLSAllowed();
 
-        // Reason reported by the TLS backend for the last failed handshake,
-        // e.g. "dh key too small". NULL when the last connect did not fail
-        // during the handshake.
+        // Reason reported by the TLS backend for the most recent rejected
+        // handshake, e.g. "dh key too small". This stays set when a later
+        // compatibility level went on to succeed, so it explains why the
+        // fallback happened; pair it with the connect error to decide whether
+        // the connection actually failed. NULL when no handshake was rejected.
         virtual String * lastTLSErrorDescription();
 
         // Compatibility level the last connect() settled on. See

--- a/Vendor/mailcore2/src/core/smtp/MCSMTPSession.cpp
+++ b/Vendor/mailcore2/src/core/smtp/MCSMTPSession.cpp
@@ -43,6 +43,9 @@ void SMTPSession::init()
     mConnectionType = ConnectionTypeClear;
     mTimeout = 30;
     mCheckCertificateEnabled = true;
+    mObsoleteTLSAllowed = false;
+    mTLSCompatibilityLevel = MAILSTREAM_SSL_COMPAT_DEFAULT;
+    mLastTLSErrorDescription = NULL;
     mUseHeloIPEnabled = false;
     mShouldDisconnect = false;
     mSendingCancelled = false;
@@ -78,6 +81,7 @@ SMTPSession::~SMTPSession()
     MC_SAFE_RELEASE(mUsername);
     MC_SAFE_RELEASE(mPassword);
     MC_SAFE_RELEASE(mOAuth2Token);
+    MC_SAFE_RELEASE(mLastTLSErrorDescription);
 }
 
 void SMTPSession::setHostname(String * hostname)
@@ -177,6 +181,26 @@ bool SMTPSession::isCheckCertificateEnabled()
     return mCheckCertificateEnabled;
 }
 
+void SMTPSession::setObsoleteTLSAllowed(bool allowed)
+{
+    mObsoleteTLSAllowed = allowed;
+}
+
+bool SMTPSession::isObsoleteTLSAllowed()
+{
+    return mObsoleteTLSAllowed;
+}
+
+String * SMTPSession::lastTLSErrorDescription()
+{
+    return mLastTLSErrorDescription;
+}
+
+int SMTPSession::tlsCompatibilityLevel()
+{
+    return mTLSCompatibilityLevel;
+}
+
 bool SMTPSession::checkCertificate()
 {
     if (!isCheckCertificateEnabled())
@@ -273,12 +297,15 @@ static bool isIPAddress(const char * hostname)
 
 static void ssl_callback(struct mailstream_ssl_context * ssl_context, void * data)
 {
+    SMTPSession * session = (SMTPSession *) data;
+
     // Set the Server Name Indication (SNI) for TLS connections
     // SNI only makes sense for hostnames, not IP addresses
-    const char * hostname = (const char *) data;
+    const char * hostname = session->hostname() != NULL ? MCUTF8(session->hostname()) : NULL;
     if (hostname != NULL && !isIPAddress(hostname)) {
         mailstream_ssl_set_server_name(ssl_context, (char *) hostname);
     }
+    mailstream_ssl_set_compatibility_level(ssl_context, session->mTLSCompatibilityLevel);
 }
 
 void SMTPSession::setup()
@@ -322,8 +349,51 @@ void SMTPSession::connectIfNeeded(ErrorCode * pError)
 
 void SMTPSession::connect(ErrorCode * pError)
 {
+    MC_SAFE_RELEASE(mLastTLSErrorDescription);
+
+    if (mConnectionType == ConnectionTypeClear) {
+        mTLSCompatibilityLevel = MAILSTREAM_SSL_COMPAT_DEFAULT;
+        connectWithCurrentCompatibilityLevel(pError);
+        return;
+    }
+
+    // See IMAPSession::connect - start strict, relax only when the TLS backend
+    // itself rejected the negotiation.
+    int maxLevel = mObsoleteTLSAllowed ? MAILSTREAM_SSL_COMPAT_OBSOLETE : MAILSTREAM_SSL_COMPAT_LEGACY;
+
+    for (int level = MAILSTREAM_SSL_COMPAT_DEFAULT; level <= maxLevel; level++) {
+        mTLSCompatibilityLevel = level;
+        connectWithCurrentCompatibilityLevel(pError);
+
+        if (* pError == ErrorNone) {
+            if (level != MAILSTREAM_SSL_COMPAT_DEFAULT) {
+                MCLog("%s uses outdated encryption, connected at TLS compatibility level %i",
+                      MCUTF8(mHostname), level);
+            }
+            return;
+        }
+
+        if (!mailstream_ssl_has_last_error()) {
+            return;
+        }
+
+        MC_SAFE_REPLACE_RETAIN(String, mLastTLSErrorDescription,
+                               String::stringWithUTF8Characters(mailstream_ssl_get_last_error()));
+
+        MCLog("TLS handshake with %s rejected at compatibility level %i: %s",
+              MCUTF8(mHostname), level, mailstream_ssl_get_last_error());
+    }
+
+    if (!mObsoleteTLSAllowed) {
+        MCLog("%s requires obsolete TLS. Enable \"Allow insecure SSL\" for this account to connect anyway.",
+              MCUTF8(mHostname));
+    }
+}
+
+void SMTPSession::connectWithCurrentCompatibilityLevel(ErrorCode * pError)
+{
     int r;
-    
+
     setup();
 
     switch (mConnectionType) {
@@ -354,7 +424,7 @@ void SMTPSession::connect(ErrorCode * pError)
             }
             
             MCLog("start TLS");
-            r = mailsmtp_socket_starttls_with_callback(mSmtp, ssl_callback, (void *) MCUTF8(mHostname));
+            r = mailsmtp_socket_starttls_with_callback(mSmtp, ssl_callback, this);
             saveLastResponse();
             mLastLibetpanError = r;
             mLastErrorLocation = 3;
@@ -387,7 +457,7 @@ void SMTPSession::connect(ErrorCode * pError)
             
         case ConnectionTypeTLS:
             r = mailsmtp_ssl_connect_with_callback(mSmtp, MCUTF8(mHostname), port(),
-                ssl_callback, (void *) MCUTF8(mHostname));
+                ssl_callback, this);
             saveLastResponse();
             mLastLibetpanError = r;
             mLastErrorLocation = 5;

--- a/Vendor/mailcore2/src/core/smtp/MCSMTPSession.cpp
+++ b/Vendor/mailcore2/src/core/smtp/MCSMTPSession.cpp
@@ -374,6 +374,9 @@ void SMTPSession::connect(ErrorCode * pError)
         }
 
         if (!mailstream_ssl_has_last_error()) {
+            // See IMAPSession::connect - don't report a reason recorded at an
+            // earlier level for a failure that wasn't a TLS rejection.
+            MC_SAFE_RELEASE(mLastTLSErrorDescription);
             return;
         }
 

--- a/Vendor/mailcore2/src/core/smtp/MCSMTPSession.cpp
+++ b/Vendor/mailcore2/src/core/smtp/MCSMTPSession.cpp
@@ -397,6 +397,9 @@ void SMTPSession::connectWithCurrentCompatibilityLevel(ErrorCode * pError)
 {
     int r;
 
+    // See IMAPSession::connectWithCurrentCompatibilityLevel.
+    mailstream_ssl_clear_last_error();
+
     setup();
 
     switch (mConnectionType) {

--- a/Vendor/mailcore2/src/core/smtp/MCSMTPSession.h
+++ b/Vendor/mailcore2/src/core/smtp/MCSMTPSession.h
@@ -47,6 +47,21 @@ namespace mailcore {
         virtual void setCheckCertificateEnabled(bool enabled);
         virtual bool isCheckCertificateEnabled();
 
+        // When enabled, a TLS handshake that fails at every safer setting is
+        // retried with OpenSSL's security level 0, which permits SHA-1 signed
+        // certificates and undersized RSA/DH parameters. Off by default.
+        virtual void setObsoleteTLSAllowed(bool allowed);
+        virtual bool isObsoleteTLSAllowed();
+
+        // Reason reported by the TLS backend for the last failed handshake,
+        // e.g. "dh key too small". NULL when the last connect did not fail
+        // during the handshake.
+        virtual String * lastTLSErrorDescription();
+
+        // Compatibility level the last connect() settled on. See
+        // MAILSTREAM_SSL_COMPAT_* in libetpan's mailstream_ssl.h.
+        virtual int tlsCompatibilityLevel();
+
         virtual String * lastSMTPResponse();
 
         virtual int lastSMTPResponseCode();
@@ -76,7 +91,12 @@ namespace mailcore {
         virtual void unlockConnectionLogger();
         virtual ConnectionLogger * connectionLoggerNoLock();
 
+        // Read by the TLS handshake callback, which is a plain C callback.
+        int mTLSCompatibilityLevel;
+
     private:
+        bool mObsoleteTLSAllowed;
+        String * mLastTLSErrorDescription;
         String * mHostname;
         unsigned int mPort;
         String * mUsername;
@@ -112,6 +132,7 @@ namespace mailcore {
         void bodyProgress(unsigned int current, unsigned int maximum);
         void setup();
         void unsetup();
+        void connectWithCurrentCompatibilityLevel(ErrorCode * pError);
         void connectIfNeeded(ErrorCode * pError);
         bool checkCertificate();
         void setSendingCancelled(bool isCancelled);

--- a/Vendor/mailcore2/src/core/smtp/MCSMTPSession.h
+++ b/Vendor/mailcore2/src/core/smtp/MCSMTPSession.h
@@ -53,9 +53,11 @@ namespace mailcore {
         virtual void setObsoleteTLSAllowed(bool allowed);
         virtual bool isObsoleteTLSAllowed();
 
-        // Reason reported by the TLS backend for the last failed handshake,
-        // e.g. "dh key too small". NULL when the last connect did not fail
-        // during the handshake.
+        // Reason reported by the TLS backend for the most recent rejected
+        // handshake, e.g. "dh key too small". This stays set when a later
+        // compatibility level went on to succeed, so it explains why the
+        // fallback happened; pair it with the connect error to decide whether
+        // the connection actually failed. NULL when no handshake was rejected.
         virtual String * lastTLSErrorDescription();
 
         // Compatibility level the last connect() settled on. See


### PR DESCRIPTION
Fixes IMAP/SMTP accounts on servers that still use legacy encryption — reported against `imap.shaw.ca:993`, which fails on Windows with "connect error 43" while the same account works on macOS.

## Diagnosis

Error 43 is libetpan's `MAILIMAP_ERROR_SSL` — the TLS handshake is rejected, not an auth or protocol problem. (It is not a mailcore code; mailcore 43 is `ErrorCustomCommand`, a red herring.)

`MCLibetpan.cpp` sets `mailstream_cfstream_enabled = 1`, so on Apple platforms libetpan routes TLS through CFStream / Security.framework, which accepts Shaw's handshake. Windows and Linux fall through to OpenSSL, which does not.

The first commit added a `legacy_tls_check` step to `--mode install-check` to confirm this in CI before changing behavior. It did, and gave the exact reason:

```
SSL_connect failed: error:0A00018A:SSL routines::dh key too small
TLS ssl connect imap.shaw.ca 993 43
```

| Platform | TLS backend | Result |
|---|---|---|
| macOS | CFStream / Security.framework | passes, full IMAP banner |
| Windows | OpenSSL 3.6.0 (vcpkg) | `dh key too small` |
| Ubuntu 22/24/25, Fedora 40/41/43, Arch, openSUSE (x64 + arm64) | OpenSSL 3.0.2 | `dh key too small` |

Gmail IMAP/SMTP and the HTTP check passed in every one of those runs, so the failure is isolated to the legacy handshake.

## Changes

**Diagnostics.** libetpan records the TLS backend's reason for a failed handshake in thread-local storage, exposed as `mailstream_ssl_get_last_error()` and `mailstream_ssl_has_last_error()`. The reason previously only reached stderr, so it never made it into Mailspring's log — which is why this took a round-trip through `s_client` to diagnose. Both IMAP and SMTP connect paths now log it next to the error code.

**Fallback.** `mailstream_ssl_set_compatibility_level()` applies progressively relaxed settings to the `SSL_CTX` before the handshake; `IMAPSession::connect` and `SMTPSession::connect` retry through them.

| Level | Effect |
|---|---|
| `DEFAULT` | OpenSSL defaults. Tried first, so a healthy server is never downgraded. |
| `LEGACY` | Allows servers without RFC 5746 secure renegotiation, allows TLS 1.0/1.1, pins security level to 1. Still requires 80 bits of security. |
| `OBSOLETE` | Security level 0. Also permits SHA-1 certificates and undersized RSA keys, so it is **gated behind the existing per-account "Allow insecure SSL" setting** rather than applied automatically. |

Two design notes:

- A retry only happens when the TLS backend itself rejected the negotiation. Unreachable hosts fail fast rather than reconnecting pointlessly, and this is more robust than matching specific `SSL_R_*` reason codes, which vary across OpenSSL versions.
- Pinning `LEGACY` to security level 1 is OpenSSL's own default; Debian and Ubuntu ship builds defaulting to 2. So this also makes behavior consistent across platforms rather than only relaxing it.

No new account settings and no client-side UI work — the obsolete tier reuses the "Allow insecure SSL" checkbox Mailspring already exposes per account.

## Verification

`install-check` now reports the compatibility level it settled on, so a server needing the obsolete tier is visible rather than silently absorbed, and a host that is merely unreachable is skipped instead of failing the build. **The level reported by this run tells us whether Shaw is reachable automatically at `LEGACY`, or whether affected users need to tick "Allow insecure SSL".**

libetpan, mailcore2 and mailsync all build clean locally with no new warnings.