### PR TITLE
Fix NetEase IMAP synchronization

### DIFF
--- a/MailSync/MailProcessor.cpp
+++ b/MailSync/MailProcessor.cpp
@@ -187,16 +187,17 @@ void MailProcessor::updateMessage(Message * local, IMAPMessage * remote, Folder 
 
     // Priority folder check: prevent lower-priority folders from claiming messages
     // that already belong to higher-priority folders. This fixes "flickering" on
-    // iCloud where the same message genuinely exists in multiple folders simultaneously.
+    // iCloud and NetEase where the same message genuinely exists in multiple folders
+    // simultaneously (for example, a message sent to yourself appears in Inbox and Sent).
     //
     // On standard IMAP servers (FastMail, etc.), messages MOVE between folders
     // (DELETE from source + APPEND to destination). The "latest folder wins" behavior
-    // is correct for these servers. The priority check is only needed for iCloud's
-    // non-standard behavior where the same message appears in multiple folders at once.
+    // is correct for these servers. The priority check is only needed for providers
+    // known to expose the same message in multiple folders at once.
     string currentFolderId = local->remoteFolderId();
-    bool isICloud = account->isICloud();
+    bool useFolderPriority = account->isICloud() || account->isNetEase();
 
-    if (isICloud && folder.id() != currentFolderId && !currentFolderId.empty()) {
+    if (useFolderPriority && folder.id() != currentFolderId && !currentFolderId.empty()) {
         bool isUnlinked = local->remoteUID() > UINT32_MAX - 5;
 
         if (isUnlinked) {

--- a/MailSync/MailUtils.cpp
+++ b/MailSync/MailUtils.cpp
@@ -790,6 +790,22 @@ void MailUtils::configureSessionForAccount(IMAPSession &session, shared_ptr<Acco
     }
     session.setHostname(AS_MCSTR(account->IMAPHost()));
     session.setPort(account->IMAPPort());
+
+    // NetEase's IMAP servers advertise RFC 2971 ID support and require clients
+    // to identify themselves after authentication. Without this, LOGIN, LIST,
+    // and STATUS succeed but SELECT is rejected with "Unsafe Login".
+    //
+    // MailCore's automatic ID exchange is enabled only when the client identity
+    // is non-empty, so providers with known-bad ID responses remain unaffected.
+    if (account->isNetEase()) {
+        IMAPIdentity clientIdentity;
+        clientIdentity.setName(MCSTR("Mailspring"));
+        clientIdentity.setVersion(MCSTR("1.0"));
+        clientIdentity.setVendor(MCSTR("Foundry 376"));
+        clientIdentity.setInfoForKey(MCSTR("support-email"), MCSTR("support@getmailspring.com"));
+        session.setClientIdentity(&clientIdentity);
+    }
+
     if (account->IMAPSecurity() == "SSL / TLS") {
         session.setConnectionType(ConnectionType::ConnectionTypeTLS);
     } else if (account->IMAPSecurity() == "STARTTLS") {

--- a/MailSync/Models/Account.cpp
+++ b/MailSync/Models/Account.cpp
@@ -9,6 +9,7 @@
 //  in 'LICENSE.md', which is part of the Mailspring-Sync package.
 //
 
+#include <algorithm>
 #include "Account.hpp"
 #include "MailUtils.hpp"
 #include "Thread.hpp"
@@ -123,6 +124,12 @@ bool Account::IMAPAllowInsecureSSL() {
 
 bool Account::isICloud() {
     return IMAPHost().find("imap.mail.me.com") != string::npos;
+}
+
+bool Account::isNetEase() {
+    string imapHost = IMAPHost();
+    transform(imapHost.begin(), imapHost.end(), imapHost.begin(), ::tolower);
+    return imapHost == "imap.163.com" || imapHost == "imap.126.com" || imapHost == "imap.yeah.net";
 }
 
 unsigned int Account::SMTPPort() {

--- a/MailSync/Models/Account.hpp
+++ b/MailSync/Models/Account.hpp
@@ -50,6 +50,7 @@ public:
     bool IMAPAllowInsecureSSL();
 
     bool isICloud();
+    bool isNetEase();
 
     unsigned int SMTPPort();
     string SMTPHost();

--- a/MailSync/SyncWorker.cpp
+++ b/MailSync/SyncWorker.cpp
@@ -9,6 +9,7 @@
 //  in 'LICENSE.md', which is part of the Mailspring-Sync package.
 //
 #include <algorithm>
+#include <map>
 #include <set>
 
 #include "SyncWorker.hpp"
@@ -47,6 +48,9 @@
 #define LS_HIGHESTMODSEQ            "highestmodseq"
 #define LS_UIDVALIDITY              "uidvalidity"
 #define LS_UIDVALIDITY_RESET_COUNT  "uidvalidityResetCount"
+#define LS_MESSAGE_COUNT            "messageCount"
+#define LS_UNSEEN_COUNT             "unseenCount"
+#define LS_RECENT_COUNT             "recentCount"
 
 using namespace mailcore;
 using namespace std;
@@ -319,20 +323,47 @@ bool SyncWorker::syncNow()
         ptrdiff_t rhsRank = find(roleOrder.begin(), roleOrder.end(), rhs->role()) - roleOrder.begin();
         return lhsRank < rhsRank;
     });
-    
+
+    // Fetch STATUS for every folder before syncing any of them. NetEase omits
+    // UIDNEXT, so if one folder's lightweight status changes we must deep-scan
+    // all folders in the same pass. This gives a lower-priority duplicate (such
+    // as Sent) a chance to reclaim a message unlinked from Inbox before phase
+    // cleanup deletes it.
+    map<string, IMAPFolderStatus *> remoteStatuses;
+    bool forceNetEaseDeepScan = false;
     for (auto & folder : folders) {
-        json & localStatus = folder->localStatus();
-        json initialLocalStatus = localStatus; // note: json not json&
-        
         String path = AS_MCSTR(folder->path());
         ErrorCode err = ErrorCode::ErrorNone;
-        IMAPFolderStatus remoteStatus = session.folderStatus(&path, &err);
-        bool firstChunk = false;
-
+        IMAPFolderStatus * remoteStatus = session.folderStatus(&path, &err);
         if (err != ErrorNone) {
             logger->warn("SyncNow: unable to get folder status for {} ({}), skipping...", folder->path(), ErrorCodeToTypeMap[err]);
             continue;
         }
+
+        remoteStatuses[folder->id()] = remoteStatus;
+        if (account->isNetEase() && remoteStatus->uidNext() == 0) {
+            json & localStatus = folder->localStatus();
+            auto changed = [&localStatus](const char * key, uint32_t value) {
+                return !localStatus.count(key) || !localStatus[key].is_number() ||
+                       localStatus[key].get<uint32_t>() != value;
+            };
+            forceNetEaseDeepScan = forceNetEaseDeepScan ||
+                                   changed(LS_MESSAGE_COUNT, remoteStatus->messageCount()) ||
+                                   changed(LS_UNSEEN_COUNT, remoteStatus->unseenCount()) ||
+                                   changed(LS_RECENT_COUNT, remoteStatus->recentCount());
+        }
+    }
+
+    for (auto & folder : folders) {
+        auto remoteStatusIt = remoteStatuses.find(folder->id());
+        if (remoteStatusIt == remoteStatuses.end()) {
+            continue;
+        }
+
+        json & localStatus = folder->localStatus();
+        json initialLocalStatus = localStatus; // note: json not json&
+        IMAPFolderStatus & remoteStatus = *remoteStatusIt->second;
+        bool firstChunk = false;
         
         // Step 1: Check folder UIDValidity
         if (localStatus.empty() || localStatus[LS_UIDVALIDITY].is_null()) {
@@ -360,6 +391,9 @@ bool SyncWorker::syncNow()
             localStatus[LS_BODIES_WANTED] = 0; // pretend we want no message contents
             localStatus[LS_SYNCED_MIN_UID] = 1; // pretend we have scanned all the way to the oldest message
             localStatus[LS_UIDNEXT] = remoteStatus.uidNext();
+            localStatus[LS_MESSAGE_COUNT] = remoteStatus.messageCount();
+            localStatus[LS_UNSEEN_COUNT] = remoteStatus.unseenCount();
+            localStatus[LS_RECENT_COUNT] = remoteStatus.recentCount();
             store->saveFolderStatus(folder.get(), initialLocalStatus);
             continue;
         }
@@ -396,6 +430,9 @@ bool SyncWorker::syncNow()
             localStatus[LS_SYNCED_MIN_UID] = 1;
             localStatus[LS_LAST_SHALLOW] = time(0);
             localStatus[LS_LAST_DEEP] = time(0);
+            localStatus[LS_MESSAGE_COUNT] = remoteStatus.messageCount();
+            localStatus[LS_UNSEEN_COUNT] = remoteStatus.unseenCount();
+            localStatus[LS_RECENT_COUNT] = remoteStatus.recentCount();
             
             store->saveFolderStatus(folder.get(), initialLocalStatus);
             continue;
@@ -430,7 +467,9 @@ bool SyncWorker::syncNow()
             uint32_t remoteUidnext = remoteStatus.uidNext();
             uint32_t localUidnext = localStatus[LS_UIDNEXT].get<uint32_t>();
             bool newMessages = remoteUidnext > localUidnext;
-            bool timeForDeepScan = (iterationsSinceLaunch > 0) && (time(0) - localStatus[LS_LAST_DEEP].get<time_t>() > DEEP_SCAN_INTERVAL);
+            bool timeForDeepScan = (forceNetEaseDeepScan && remoteUidnext == 0) ||
+                                   ((iterationsSinceLaunch > 0) &&
+                                    (time(0) - localStatus[LS_LAST_DEEP].get<time_t>() > DEEP_SCAN_INTERVAL));
             bool timeForShallowScan = !timeForDeepScan && (time(0) - localStatus[LS_LAST_SHALLOW].get<time_t>() > SHALLOW_SCAN_INTERVAL);
 
             // Okay. If there are new messages in the folder (UIDnext has increased), do a heavy fetch of
@@ -476,11 +515,19 @@ bool SyncWorker::syncNow()
             
             if (timeForDeepScan) {
                 syncFolderUIDRange(*folder, RangeMake(syncedMinUID, UINT64_MAX), false);
+                if (syncedMinUID == 0) {
+                    syncedMinUID = 1;
+                    localStatus[LS_SYNCED_MIN_UID] = 1;
+                }
                 localStatus[LS_LAST_SHALLOW] = time(0);
                 localStatus[LS_LAST_DEEP] = time(0);
                 localStatus[LS_UIDNEXT] = remoteUidnext;
             }
         }
+
+        localStatus[LS_MESSAGE_COUNT] = remoteStatus.messageCount();
+        localStatus[LS_UNSEEN_COUNT] = remoteStatus.unseenCount();
+        localStatus[LS_RECENT_COUNT] = remoteStatus.recentCount();
         
         bool moreToDo = false;
 

--- a/Vendor/mailcore2/src/core/imap/MCIMAPSession.cpp
+++ b/Vendor/mailcore2/src/core/imap/MCIMAPSession.cpp
@@ -1038,6 +1038,22 @@ void IMAPSession::login(ErrorCode * pError)
     enableFeatures();
 
     if (isAutomaticConfigurationEnabled()) {
+        // Some providers (notably NetEase 163/126/yeah.net) accept LOGIN but
+        // reject SELECT with "Unsafe Login" until the client sends RFC 2971 ID.
+        // Only perform the exchange when the caller supplied identity fields;
+        // the default identity is empty, preserving compatibility with servers
+        // whose malformed ID responses cannot be parsed by MailCore.
+        if (isIdentityEnabled() && clientIdentity()->allInfoKeys()->count() > 0) {
+            IMAPIdentity * serverIdentity = identity(clientIdentity(), pError);
+            if (* pError != ErrorNone) {
+                MCLog("fetch identity failed");
+                return;
+            }
+            else {
+                MC_SAFE_REPLACE_RETAIN(IMAPIdentity, mServerIdentity, serverIdentity);
+            }
+        }
+
         bool hasDefaultNamespace = false;
         if (isNamespaceEnabled()) {
             HashMap * result = fetchNamespace(pError);
@@ -1079,22 +1095,6 @@ void IMAPSession::login(ErrorCode * pError)
             setDefaultNamespace(defaultNamespace);
         }
         
-#if 0
-/* This code is sensitive to the escaping of fields in the identity response,
- (breaks ProtonMail support) and isn't used anywhere in Mailspring. See
- https://github.com/Foundry376/Mailspring/issues/429
-*/
-        if (isIdentityEnabled()) {
-            IMAPIdentity * serverIdentity = identity(clientIdentity(), pError);
-            if (* pError != ErrorNone) {
-                // Ignore identity errors
-                MCLog("fetch identity failed");
-            }
-            else {
-                MC_SAFE_REPLACE_RETAIN(IMAPIdentity, mServerIdentity, serverIdentity);
-            }
-        }
-#endif
     }
     else {
         // TODO: namespace should be shared with other sessions for non automatic namespace.


### PR DESCRIPTION
## Summary

NetEase IMAP servers used by 163.com, 126.com, and yeah.net advertise RFC 2971 `ID` but reject `SELECT` with `Unsafe Login` unless the client identifies itself after authentication.

This change:

- configures a Mailspring client identity for the three NetEase IMAP hosts;
- sends `ID` after LOGIN/CAPABILITY and before NAMESPACE/LIST/SELECT on each physical connection;
- propagates ID transport and parse failures instead of continuing with an inconsistent connection;
- handles NetEase responses that omit `UIDNEXT` by tracking lightweight STATUS fingerprints (message, unseen, and recent counts);
- coordinates a same-pass deep scan of all NetEase folders when a fingerprint changes, so duplicate copies can be reclaimed before unlink cleanup;
- applies existing folder-priority behavior to NetEase so a self-sent message present in both Inbox and Sent remains visible in Inbox.

The fallback is scoped to exact NetEase hosts with a missing UIDNEXT, so existing non-NetEase accounts do not perform a migration-time full scan.

Related community report: https://community.getmailspring.com/t/cannot-sync-126-163-mails-because-setting-up-snooze-subfolder-in-mail-folders-is-not-allowed/562

## Testing

- Built the Win32 Release solution with MSBuild 17.14 and the repository's pinned vcpkg configuration.
- Tested against a real 163.com account:
  - LOGIN succeeded;
  - both foreground and background connections sent `ID` and received `OK ID completed`;
  - `SELECT INBOX`, `UID FETCH 1:*`, full-header fetches, and message-body fetches succeeded;
  - an Inbox with four remote messages was fully represented locally;
  - a self-sent message duplicated in Inbox and Sent remained assigned to Inbox;
  - two subsequent two-minute polling cycles completed without unnecessary deep scans or sync errors.
- Ran `git diff --check`.

## Known limitation

After ID succeeds, 163.com accepts creation of the top-level `Mailspring` folder but rejects the nested `Mailspring/Snoozed` folder. This PR leaves the existing best-effort helper-folder behavior unchanged because disabling it also requires corresponding Snooze UI behavior.
