### PR TITLE
Sync engine hardening: crash safety, XML escaping, and log hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ Makefile
 cmake_install.cmake
 /mailsync
 /Vendor/mailcore2/build/
+
+# Local build prefix for vendored libetpan (see BUILDING.md)
+/Vendor/_install/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,34 +70,41 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
   target_link_libraries(mailsync libMailCore.a)
   target_link_libraries(mailsync ${GLIB_LIBRARIES})
-  target_link_libraries(mailsync libetpan.a)
+  # Static only: build.sh bundles no libetpan, and its ldd sweep collects just libsasl2, so a
+  # shared match would produce a binary that cannot start on a machine without libetpan.
+  find_library(ETPAN_LIB NAMES libetpan.a REQUIRED)
+  target_link_libraries(mailsync ${ETPAN_LIB})
 
-  find_library(XML_LIB NAMES libxml2.a libxml2)
+  # Prefer the static archive, fall back to the shared library. The fallback must be the bare
+  # name ("xml2"): CMake treats a NAMES entry carrying the platform prefix as a literal
+  # filename and stops trying suffixes, so "libxml2" matches nothing where only libxml2.so
+  # is installed.
+  find_library(XML_LIB NAMES libxml2.a xml2 REQUIRED)
   target_link_libraries(mailsync ${XML_LIB})
   target_include_directories(mailsync PRIVATE /usr/include/libxml2)
 
-  find_library(LZMA_LIB NAMES liblzma.a liblzma)
+  find_library(LZMA_LIB NAMES liblzma.a lzma REQUIRED)
   target_link_libraries(mailsync ${LZMA_LIB})
 
-  find_library(Z_LIB NAMES libz.a libz)
+  find_library(Z_LIB NAMES libz.a z REQUIRED)
   target_link_libraries(mailsync ${Z_LIB})
 
-  find_library(RESOLV_LIB NAMES libresolv.a libresolv)
+  find_library(RESOLV_LIB NAMES libresolv.a resolv REQUIRED)
   target_link_libraries(mailsync ${RESOLV_LIB})
 
-  find_library(CTEMPLATE_LIB NAMES libctemplate.a libctemplate)
+  find_library(CTEMPLATE_LIB NAMES libctemplate.a ctemplate REQUIRED)
   target_link_libraries(mailsync ${CTEMPLATE_LIB})
 
-  find_library(UUID_LIB NAMES libuuid.a libuuid)
+  find_library(UUID_LIB NAMES libuuid.a uuid REQUIRED)
   target_link_libraries(mailsync ${UUID_LIB})
 
-  find_library(ICUI18N_LIB NAMES libicui18n.a libicui18n)
+  find_library(ICUI18N_LIB NAMES libicui18n.a icui18n REQUIRED)
   target_link_libraries(mailsync ${ICUI18N_LIB})
 
-  find_library(ICUUC_LIB NAMES libicuuc.a libicuuc)
+  find_library(ICUUC_LIB NAMES libicuuc.a icuuc REQUIRED)
   target_link_libraries(mailsync ${ICUUC_LIB})
 
-  find_library(ICUDATA_LIB NAMES libicudata.a libicudata)
+  find_library(ICUDATA_LIB NAMES libicudata.a icudata REQUIRED)
   target_link_libraries(mailsync ${ICUDATA_LIB})
 
   pkg_check_modules(CARES REQUIRED libcares)

--- a/MailSync/DAVWorker.cpp
+++ b/MailSync/DAVWorker.cpp
@@ -257,6 +257,25 @@ static string hrefForNewEvent(const string & calendarPath, shared_ptr<Event> eve
     return calendarPath + uid + ".ics";
 }
 
+// Escape text destined for an XML text node, so an href taken from a server response cannot
+// close its element and introduce siblings. Hrefs are echoed straight back into the body of a
+// multiget, and they arrive from the server rather than from us.
+static string xmlEscape(const string & text) {
+    string out;
+    out.reserve(text.size());
+    for (char c : text) {
+        switch (c) {
+            case '&': out += "&amp;"; break;
+            case '<': out += "&lt;"; break;
+            case '>': out += "&gt;"; break;
+            case '"': out += "&quot;"; break;
+            case '\'': out += "&apos;"; break;
+            default: out += c;
+        }
+    }
+    return out;
+}
+
 // Rate limiting constants (RFC 6585/7231 compliance)
 static const int MAX_BACKOFF_MS = 60000;  // 1 minute max backoff
 static const int MIN_BACKOFF_MS = 100;    // 100ms minimum when backing off
@@ -883,7 +902,7 @@ void DAVWorker::runForAddressBook(shared_ptr<ContactBook> ab) {
     for (auto chunk : MailUtils::chunksOfVector(needed, 90)) {
         string payload = "";
         for (auto & href : chunk) {
-            payload += "<d:href>" + href + "</d:href>";
+            payload += "<d:href>" + xmlEscape(href) + "</d:href>";
         }
 
         // Fetch the data
@@ -904,7 +923,7 @@ void DAVWorker::runForAddressBook(shared_ptr<ContactBook> ab) {
             }
             auto vcard = make_shared<VCard>(vcardString);
             if (vcard->incomplete()) {
-                logger->info("Unable to decode vcard: {}", vcardString);
+                logger->info("Unable to decode vcard ({} bytes)", vcardString.size());
                 return;
             }
             string id = vcard->getUniqueId()->getValue();
@@ -1136,7 +1155,7 @@ bool DAVWorker::runForAddressBookWithSyncToken(shared_ptr<ContactBook> ab, int r
         for (auto chunk : MailUtils::chunksOfVector(neededHrefs, 90)) {
             string payload = "";
             for (auto & href : chunk) {
-                payload += "<d:href>" + href + "</d:href>";
+                payload += "<d:href>" + xmlEscape(href) + "</d:href>";
             }
 
             auto abDoc = performXMLRequest(ab->url(), "REPORT",
@@ -1158,7 +1177,7 @@ bool DAVWorker::runForAddressBookWithSyncToken(shared_ptr<ContactBook> ab, int r
                 }
                 auto vcard = make_shared<VCard>(vcardString);
                 if (vcard->incomplete()) {
-                    logger->info("Unable to decode vcard: {}", vcardString);
+                    logger->info("Unable to decode vcard ({} bytes)", vcardString.size());
                     return;
                 }
                 string id = vcard->getUniqueId()->getValue();
@@ -1287,7 +1306,7 @@ shared_ptr<Contact> DAVWorker::ingestAddressDataNode(shared_ptr<DavXML> doc, xml
     
     auto vcard = make_shared<VCard>(vcardString);
     if (vcard->incomplete()) {
-        logger->info("Unable to decode vcard: {}", vcardString);
+        logger->info("Unable to decode vcard ({} bytes)", vcardString.size());
         return nullptr;
     }
     string id = vcard->getUniqueId()->getValue();
@@ -1662,7 +1681,7 @@ void DAVWorker::runForCalendar(string calendarId, string name, string url) {
     for (auto chunk : MailUtils::chunksOfVector(neededHrefs, 90)) {
         string payload = "";
         for (auto & href : chunk) {
-            payload += "<d:href>" + href + "</d:href>";
+            payload += "<d:href>" + xmlEscape(href) + "</d:href>";
         }
 
         // Fetch the data (rate limiting is now handled in performXMLRequest)
@@ -1693,7 +1712,8 @@ void DAVWorker::runForCalendar(string calendarId, string name, string url) {
             // Process ALL VEVENTs in the ICS file (master + any recurrence exceptions)
             for (auto icsEvent : cal->Events) {
                 if (icsEvent->DtStart.IsEmpty()) {
-                    logger->info("Received calendar event but it has no start time?\n\n{}\n\n", icsData);
+                    logger->info("Received calendar event with no start time: {} ({} bytes)",
+                                 href, icsData.size());
                     continue;
                 }
                 parsedEvents.push_back({etag, href, icsData, icsEvent});
@@ -2177,7 +2197,11 @@ string DAVWorker::performVCardRequest(string _url, string method, string vcard, 
     curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDS, payloadChars);
     
-    logger->info("{}: {} {}", _url, vcard, existingEtag);
+    if (MailUtils::isVerboseLoggingEnabled()) {
+        logger->info("{}: {} {}", _url, vcard, existingEtag);
+    } else {
+        logger->info("{}: {} bytes etag:{}", _url, vcard.size(), existingEtag);
+    }
     string result = PerformRequest(curl_handle);
     return result;
 }
@@ -2203,7 +2227,13 @@ string DAVWorker::performICSRequest(string _url, string method, string icsData, 
     curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDS, payloadChars);
 
-    logger->info("performICSRequest: {} {} etag:{}, data: {}", method, _url, existingEtag, icsData);
+    // The ICS body carries the event's title, attendees and description, so it only goes to
+    // the log when the user has explicitly turned on verbose logging to debug a sync problem.
+    if (MailUtils::isVerboseLoggingEnabled()) {
+        logger->info("performICSRequest: {} {} etag:{}, data: {}", method, _url, existingEtag, icsData);
+    } else {
+        logger->info("performICSRequest: {} {} etag:{}, {} bytes", method, _url, existingEtag, icsData.size());
+    }
     string result = PerformRequest(curl_handle);
     return result;
 }
@@ -2243,7 +2273,7 @@ void DAVWorker::writeAndResyncEvent(shared_ptr<Event> event) {
     auto icsDoc = performXMLRequest(calendarUrl, "REPORT",
         "<c:calendar-multiget xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\">"
         "<d:prop><d:getetag /><c:calendar-data /></d:prop>"
-        "<d:href>" + href + "</d:href>"
+        "<d:href>" + xmlEscape(href) + "</d:href>"
         "</c:calendar-multiget>");
 
     // 5. Parse response and update local event

--- a/MailSync/MailStore.cpp
+++ b/MailSync/MailStore.cpp
@@ -197,7 +197,12 @@ void MailStore::assertCorrectThread() {
      prepare half the values, and execute it, creating a rediculous data inconsistency.
      */
     if (spdlog::details::os::thread_id() != _owningThread) {
-        spdlog::get("logger")->error("MailStore thread assertion failure: function called on {} instead of {}", spdlog::details::os::thread_id(), _owningThread);
+        // Null before main() registers the logger, which the --mode migrate path never
+        // reaches. The throw below is what actually reports this; losing the log line is
+        // better than turning an assertion into a segfault. See MailStoreTransaction::commit.
+        if (auto logger = spdlog::get("logger")) {
+            logger->error("MailStore thread assertion failure: function called on {} instead of {}", spdlog::details::os::thread_id(), _owningThread);
+        }
         throw SyncException("assertion-failure", "MailStore thread assertion failure", false);
     }
 }

--- a/MailSync/MailStoreTransaction.cpp
+++ b/MailSync/MailStoreTransaction.cpp
@@ -43,11 +43,19 @@ void MailStoreTransaction::commit()
         long long waitingMs = duration_cast<std::chrono::milliseconds>(mBegan - mStart).count();
         long long selfMs = duration_cast<std::chrono::milliseconds>(now - mBegan).count();
 
-        if (waitingMs > 1000) {
-            spdlog::get("logger")->warn("[BUSY] Transaction={} waited {}ms to acquire write lock", mNameHint, waitingMs);
-        }
-        if (selfMs > 100) {
-            spdlog::get("logger")->warn("[SLOW] Transaction={} held write lock for {}ms", mNameHint, selfMs);
+        // spdlog::get returns null until main() registers the logger, and it does that only
+        // after the --mode migrate path has already run to completion. These timings are
+        // diagnostics, so an absent logger means skip them rather than crash: dereferencing
+        // it here segfaulted the schema migration on any calendar big enough to hold the
+        // write lock for 100ms, which is every real one.
+        auto logger = spdlog::get("logger");
+        if (logger) {
+            if (waitingMs > 1000) {
+                logger->warn("[BUSY] Transaction={} waited {}ms to acquire write lock", mNameHint, waitingMs);
+            }
+            if (selfMs > 100) {
+                logger->warn("[SLOW] Transaction={} held write lock for {}ms", mNameHint, selfMs);
+            }
         }
         
     } else {

--- a/MailSync/MailUtils.cpp
+++ b/MailSync/MailUtils.cpp
@@ -736,6 +736,10 @@ void MailUtils::enableVerboseLogging() {
     _verboseLogging = true;
 }
 
+bool MailUtils::isVerboseLoggingEnabled() {
+    return _verboseLogging;
+}
+
 class MailcoreSPDLogger : public ConnectionLogger {
   public:
     void log(string str) {

--- a/MailSync/MailUtils.hpp
+++ b/MailSync/MailUtils.hpp
@@ -84,6 +84,7 @@ public:
     static XOAuth2Parts userAndTokenFromXOAuth2(string xoauth2);
 
     static void enableVerboseLogging();
+    static bool isVerboseLoggingEnabled();
     static void configureSessionForAccount(IMAPSession & session, shared_ptr<Account> account);
     static void configureSessionForAccount(SMTPSession & session, shared_ptr<Account> account);
 

--- a/MailSync/Models/Event.cpp
+++ b/MailSync/Models/Event.cpp
@@ -105,7 +105,10 @@ string Event::icsUID()
 
 string Event::etag()
 {
-    return _data["etag"].get<string>();
+    // Absent on an Event deserialised from client JSON, which carries no etag: reading it as
+    // required would throw json::type_error, which is not a SyncException and so aborts the
+    // process rather than failing the task.
+    return _data.count("etag") ? _data["etag"].get<string>() : "";
 }
 
 void Event::setEtag(string etag)


### PR DESCRIPTION
Groundwork extracted from a calendar PR that follows shortly. None of it is calendar-specific and all of it applies to the contact sync that ships today, so it seemed better reviewed on its own than buried in a large feature diff. Happy to fold it back in if you'd rather review it together.

### A null logger no longer crashes

`MailStoreTransaction::commit` dereferences `spdlog::get("logger")` to report a slow transaction, and `MailStore`'s thread assertion does the same to report a violation. But `main()` registers that logger only *after* the `--mode migrate` path has already run to completion, so it is null for anything reachable from `MailStore::migrate()`.

No migration uses a transaction today, which is the only reason this hasn't been hit — one that did would segfault instead of migrating, and the client would then offer "Rebuild", which resets the user's local cache. Both call sites now skip the line rather than crash. The thread assertion still throws, which is what actually reports it.

### Hrefs are XML-escaped before being echoed into a multiget body

Hrefs come back from the server, and both the CardDAV and CalDAV sync paths interpolate them straight into request XML, where an unescaped one can close its element and introduce siblings.

### Request bodies stay out of the log unless verbose is on

A vCard carries names, postal addresses and phone numbers; an ICS carries an event's title, attendees and description. All were logged in full on every write, and a failed vCard decode logged the entire card. They're reduced to a byte count unless the user has deliberately enabled verbose logging, which is what `MailUtils::isVerboseLoggingEnabled` now exposes.

### Smaller fixes

`Event::etag()` tolerates its own absence rather than throwing `json::type_error` on an Event deserialised from client JSON, which carries no etag — that error isn't a `SyncException`, so it aborts the process rather than failing a task.

Linux build: `find_library` calls are marked `REQUIRED`, so a missing dependency fails at configure time naming the library rather than at link with an empty variable. The shared-library fallbacks are corrected to bare names — CMake treats a `NAMES` entry carrying the `lib` prefix as a literal filename and stops trying suffixes, so `libxml2` matched nothing where only `libxml2.so` was installed. libetpan is pinned to the static archive, since `build.sh` bundles no libetpan and its `ldd` sweep collects only libsasl2, so a shared match produced a binary that couldn't start.

### Testing

Builds clean on Linux (GCC). Not built on macOS or Windows — no new source files, so no `.xcodeproj` / `.vcxproj` changes are needed, and the CMake changes are inside the existing Linux-only block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)