### PR TITLE
Calendar scheduling: iTIP COUNTER, calendar ownership, and UTC time correctness

### DIFF
--- a/MailSync/DAVWorker.cpp
+++ b/MailSync/DAVWorker.cpp
@@ -247,14 +247,30 @@ static string normalizeHref(const string & href) {
 
 // Generate the CalDAV resource href for a new event that has no stored href yet.
 //
-// Returns the CalDAV resource href for an event. Exceptions are embedded inline in
-// the master's VCALENDAR (RFC 4791 §4.1), so all events use "{uid}.ics".
+// Exceptions are embedded inline in the master's VCALENDAR (RFC 4791 section 4.1), so all
+// events use "{uid}.ics".
+//
+// The UID reaches us from an ICS the user did not write - an invitation attached to any
+// message can be stored on a calendar - and it lands in a request path and in the body of a
+// calendar-multiget. A UID carrying dot segments or a slash would address a different
+// resource once libcurl normalises the path, so anything outside the unreserved set earns a
+// generated name instead. The UID inside the ICS is untouched; only the resource name here
+// is constrained, which RFC 4791 section 5.3.2 leaves to the client.
 static string hrefForNewEvent(const string & calendarPath, shared_ptr<Event> event) {
     string uid = event->icsUID();
-    if (uid.empty()) {
-        uid = MailUtils::idRandomlyGenerated();
+    bool safe = !uid.empty() && uid.size() <= 200;
+    for (char c : uid) {
+        if (!(isalnum((unsigned char)c) || c == '-' || c == '_' || c == '.' || c == '@')) {
+            safe = false;
+            break;
+        }
     }
-    return calendarPath + uid + ".ics";
+    // A leading dot cannot begin a traversal on its own once the above holds, but ".." is
+    // still a name worth refusing outright.
+    if (safe && uid.find("..") != string::npos) {
+        safe = false;
+    }
+    return calendarPath + (safe ? uid : MailUtils::idRandomlyGenerated()) + ".ics";
 }
 
 // Escape text destined for an XML text node, so an href taken from a server response cannot
@@ -718,6 +734,8 @@ string DAVWorker::resolveCalendarHomeURL() {
     if (calPrincipalURL.find("://") == string::npos) {
         calPrincipalURL = replacePath(calRoot, calPrincipalURL);
     }
+
+    cachedCalPrincipalPath = normalizeHref(calPrincipalURL);
 
     // PROPFIND principal → calendar-home-set (RFC 4791 §6.2.1)
     auto homeSetDoc = performXMLRequest(calPrincipalURL, "PROPFIND",
@@ -1371,6 +1389,67 @@ void DAVWorker::rebuildContactGroup(shared_ptr<Contact> contact) {
     group->syncMembers(store, members);
 }
 
+/*
+ Whether the server says this calendar's events may be changed.
+
+ DAV:current-user-privilege-set is optional (RFC 3744 section 5.4). A server that omits it is
+ not declaring the calendar read-only, so an absent set counts as writable and the server is
+ left to reject the write if it disagrees; refusing locally would make every calendar on such
+ a server permanently uneditable. DAV:write is an aggregate, and servers may advertise the
+ privileges it contains rather than DAV:write itself, so DAV:write-content, DAV:bind and
+ DAV:all each independently mean writable.
+
+ The lookup is scoped to the propstat carrying a 200 status. A multistatus also carries a
+ propstat for the properties the server does not have, with those elements present but empty
+ (RFC 4918 section 9.1), and an unscoped match finds that one - reporting every calendar
+ read-only on exactly the servers that omit the property.
+
+ @param advertised Set to whether the server supplied the property at all.
+*/
+static bool calendarIsWritable(shared_ptr<DavXML> doc, xmlNodePtr responseNode, bool & advertised) {
+    const string found =
+        "./D:propstat[contains(./D:status, '200')]/D:prop/D:current-user-privilege-set";
+
+    advertised = false;
+    doc->evaluateXPath(found, ([&](xmlNodePtr) { advertised = true; }), responseNode);
+    if (!advertised) {
+        return true;
+    }
+
+    bool writable = false;
+    doc->evaluateXPath(found + "//D:write|" + found + "//D:write-content|" + found +
+                           "//D:bind|" + found + "//D:all",
+                       ([&](xmlNodePtr) { writable = true; }), responseNode);
+    return writable;
+}
+
+/*
+ Whether this calendar belongs to the account we are syncing, rather than being one somebody
+ else has shared with it.
+
+ DAV:owner (RFC 3744 section 5.1) names the principal that owns the collection, which is the
+ server's own answer to the question. It matters because the client uses "is this calendar
+ mine" to pick which copy of an invitation to write an RSVP onto, and the alternative signal
+ - the calendar's display name - is text any sharer chooses. Someone who shares a writable
+ calendar named after the recipient's own address would otherwise capture their replies.
+
+ Returns "mine", "other", or "" when the server declines to say; an empty answer leaves the
+ client on its previous heuristic rather than asserting something unfounded.
+ */
+static string calendarOwnership(shared_ptr<DavXML> doc, xmlNodePtr responseNode,
+                                const string & principalPath) {
+    if (principalPath.empty()) {
+        return "";
+    }
+    const string ownerPath =
+        "./D:propstat[contains(./D:status, '200')]/D:prop/D:owner/D:href/text()";
+    string owner = doc->nodeContentAtXPath(ownerPath, responseNode);
+    if (owner.empty()) {
+        return "";
+    }
+    return normalizeHref(owner) == principalPath ? "mine" : "other";
+}
+
 void DAVWorker::runCalendars() {
     // Gmail uses calHost/calPrincipal set in constructor.
     // All other accounts use dynamic discovery (cached after first run).
@@ -1420,6 +1499,7 @@ void DAVWorker::runCalendars() {
         "<ical:calendar-color />"
         "<c:calendar-description />"
         "<d:current-user-privilege-set />"
+        "<d:owner />"
         "<ical:calendar-order />"
         "</d:prop>"
         "</d:propfind>";
@@ -1445,6 +1525,14 @@ void DAVWorker::runCalendars() {
 
     auto local = store->findAllMap<Calendar>(Query().equal("accountId", account->id()), "id");
 
+    // One line per sync recording what the server said about each calendar. Whether a
+    // calendar is writable decides whether the entire calendar UI is interactive, and it is
+    // derived from a property servers are free to omit - so when the UI is inert this is the
+    // first thing worth being able to read back out of a log.
+    vector<string> writableNames {};
+    vector<string> readOnlyNames {};
+    vector<string> noPrivilegeSetNames {};
+
     // Filter calendars by supported-calendar-component-set to only sync those with VEVENT.
     // This is the RFC 4791 compliant way to discover event calendars, as opposed to
     // task lists (VTODO) or journal calendars (VJOURNAL). By filtering at discovery time,
@@ -1464,14 +1552,18 @@ void DAVWorker::runCalendars() {
         auto description = calendarSetDoc->nodeContentAtXPath(".//caldav:calendar-description/text()", node);
         auto orderStr = calendarSetDoc->nodeContentAtXPath(".//ical:calendar-order/text()", node);
 
-        // Check for write privilege to determine read-only status
-        // Use XPath to look for write elements within current-user-privilege-set
-        // RFC 3744 defines <D:write/> nested within <D:privilege> elements
-        bool hasWritePrivilege = false;
-        calendarSetDoc->evaluateXPath(".//D:current-user-privilege-set//D:write", ([&](xmlNodePtr) {
-            hasWritePrivilege = true;
-        }), node);
-        bool readOnly = !hasWritePrivilege;
+        bool advertisedPrivileges = false;
+        bool readOnly = !calendarIsWritable(calendarSetDoc, node, advertisedPrivileges);
+        // calPrincipal is the Gmail path's principal; cachedCalPrincipalPath the discovered
+        // one. Exactly one is ever set.
+        auto ownership = calendarOwnership(
+            calendarSetDoc, node,
+            calHost != "" ? normalizeHref(calPrincipal) : cachedCalPrincipalPath);
+
+        (readOnly ? readOnlyNames : writableNames).push_back(name);
+        if (!advertisedPrivileges) {
+            noPrivilegeSetNames.push_back(name);
+        }
 
         shared_ptr<Calendar> calendar = local[id];
         bool needsSync = true;
@@ -1500,6 +1592,13 @@ void DAVWorker::runCalendars() {
             if (calendar->readOnly() != readOnly) {
                 calendar->setReadOnly(readOnly);
                 metadataChanged = true;
+                logger->info("Calendar '{}' is now {}", name, readOnly ? "read-only" : "writable");
+            }
+            // Only overwrite a known answer with another known answer: a server that stops
+            // returning DAV:owner shouldn't erase what it told us last time.
+            if (!ownership.empty() && calendar->ownership() != ownership) {
+                calendar->setOwnership(ownership);
+                metadataChanged = true;
             }
             if (!orderStr.empty()) {
                 try {
@@ -1525,6 +1624,11 @@ void DAVWorker::runCalendars() {
             }
             calendar->setDescription(description);
             calendar->setReadOnly(readOnly);
+            calendar->setOwnership(ownership);
+            const char * writability = readOnly ? "read-only"
+                                     : advertisedPrivileges ? "writable"
+                                     : "writable, server advertises no privilege set";
+            logger->info("Discovered calendar '{}' ({})", name, writability);
             if (!orderStr.empty()) {
                 try {
                     calendar->setOrder(std::stoi(orderStr));
@@ -1560,6 +1664,12 @@ void DAVWorker::runCalendars() {
             }
         }
     }));
+
+    logger->info("Calendar privileges: {} writable, {} read-only ({} advertised no privilege set)",
+                 writableNames.size(), readOnlyNames.size(), noPrivilegeSetNames.size());
+    for (auto & n : readOnlyNames) {
+        logger->info("  read-only: {}", n);
+    }
 }
 
 void DAVWorker::runForCalendar(string calendarId, string name, string url) {
@@ -2340,7 +2450,7 @@ void DAVWorker::deleteEvent(shared_ptr<Event> event) {
     string existingEtag = event->etag();
     performICSRequest(fullUrl, "DELETE", "", existingEtag);
 
-    // 4. Remove from local database
+    // 4. Remove from local database, only now that the server has accepted
     store->remove(event.get());
     logger->info("Event deleted successfully: {}", href);
 }

--- a/MailSync/DAVWorker.cpp
+++ b/MailSync/DAVWorker.cpp
@@ -270,7 +270,12 @@ static string hrefForNewEvent(const string & calendarPath, shared_ptr<Event> eve
     if (safe && uid.find("..") != string::npos) {
         safe = false;
     }
-    return calendarPath + (safe ? uid : MailUtils::idRandomlyGenerated()) + ".ics";
+    // The fallback has to be a function of the event, not a fresh random id: writeAndResyncEvent
+    // and deleteEvent both call this to reconstruct an href they never stored, so two calls that
+    // disagree create a second resource with the same UID - which SabreDAV and Radicale reject
+    // with no-uid-conflict (RFC 4791 section 5.3.2) - and then leave the event undeletable.
+    // event->id() is already a hash of accountId, calendarId, UID and RECURRENCE-ID, in base58.
+    return calendarPath + (safe ? uid : event->id()) + ".ics";
 }
 
 // Escape text destined for an XML text node, so an href taken from a server response cannot
@@ -1551,8 +1556,18 @@ void DAVWorker::runCalendars() {
     vector<string> readOnlyNames {};
     vector<string> noPrivilegeSetNames {};
     // Which calendars the server actually listed this pass, so the ones it didn't can be
-    // pruned below.
-    set<string> seenIds {};
+    // pruned below. This is deliberately every response in the multistatus, not just the ones
+    // that passed the VEVENT filter: a 207 is per-resource (RFC 4918 section 9.1), so one
+    // calendar's properties can come back in an error propstat while its neighbours succeed,
+    // and treating that as "the server no longer lists it" would delete a calendar and every
+    // event on it over a transient failure.
+    set<string> listedIds {};
+    calendarSetDoc->evaluateXPath("//D:response", ([&](xmlNodePtr node) {
+        auto path = calendarSetDoc->nodeContentAtXPath("./D:href/text()", node);
+        if (!path.empty()) {
+            listedIds.insert(MailUtils::idForCalendar(account->id(), path));
+        }
+    }));
 
     // Filter calendars by supported-calendar-component-set to only sync those with VEVENT.
     // This is the RFC 4791 compliant way to discover event calendars, as opposed to
@@ -1571,7 +1586,6 @@ void DAVWorker::runCalendars() {
         auto path = calendarSetDoc->nodeContentAtXPath("./D:href/text()", node);
         auto ctag = calendarSetDoc->nodeContentAtXPath(".//cs:getctag/text()", node);
         auto id = MailUtils::idForCalendar(account->id(), path);
-        seenIds.insert(id);
 
         // Extract calendar metadata
         auto color = calendarSetDoc->nodeContentAtXPath(".//ical:calendar-color/text()", node);
@@ -1705,14 +1719,14 @@ void DAVWorker::runCalendars() {
      its events stayed in range queries - counting towards conflicts and free/busy for a
      calendar the user cannot see any more.
 
-     Guarded on having seen at least one calendar. Reaching here already means the multistatus
+     Guarded on the server having listed at least one calendar. Reaching here already means the multistatus
      parsed, since every failure path above returns early, but pruning against an empty result
      would erase every calendar on the account and re-download them, so the cheap check earns
      its place.
      */
-    if (!seenIds.empty()) {
+    if (!listedIds.empty()) {
         for (auto & pair : local) {
-            if (seenIds.count(pair.first)) {
+            if (listedIds.count(pair.first)) {
                 continue;
             }
             auto events = store->findAll<Event>(Query().equal("calendarId", pair.first));

--- a/MailSync/DAVWorker.cpp
+++ b/MailSync/DAVWorker.cpp
@@ -1447,7 +1447,14 @@ static string calendarOwnership(shared_ptr<DavXML> doc, xmlNodePtr responseNode,
     if (owner.empty()) {
         return "";
     }
-    return normalizeHref(owner) == principalPath ? "mine" : "other";
+
+    // Google's CalDAV principal resource is "<calendar-home>/user", so the owner href of an
+    // account's own calendar is the principal path with "/user" appended - the Gmail branch
+    // synthesises calPrincipal without it. On a server we discovered properly,
+    // cachedCalPrincipalPath is the real DAV:current-user-principal and matches outright.
+    const string normalized = normalizeHref(owner);
+    const bool mine = normalized == principalPath || normalized == principalPath + "/user";
+    return mine ? "mine" : "other";
 }
 
 void DAVWorker::runCalendars() {
@@ -1532,6 +1539,9 @@ void DAVWorker::runCalendars() {
     vector<string> writableNames {};
     vector<string> readOnlyNames {};
     vector<string> noPrivilegeSetNames {};
+    // Which calendars the server actually listed this pass, so the ones it didn't can be
+    // pruned below.
+    set<string> seenIds {};
 
     // Filter calendars by supported-calendar-component-set to only sync those with VEVENT.
     // This is the RFC 4791 compliant way to discover event calendars, as opposed to
@@ -1543,9 +1553,14 @@ void DAVWorker::runCalendars() {
         // Make a few xpath queries relative to the "D:response" calendar node (using "./")
         // to retrieve the attributes we're interested in.
         auto name = calendarSetDoc->nodeContentAtXPath(".//D:displayname/text()", node);
-        auto path = calendarSetDoc->nodeContentAtXPath(".//D:href/text()", node);
+        // The response's OWN href, as a direct child. Not ".//D:href": nodeContentAtXPath
+        // keeps the last node it visits, and DAV:owner carries a nested href, so a
+        // descendant search returns the owning principal's URL and every calendar ends up
+        // pointed at a principal instead of its own collection.
+        auto path = calendarSetDoc->nodeContentAtXPath("./D:href/text()", node);
         auto ctag = calendarSetDoc->nodeContentAtXPath(".//cs:getctag/text()", node);
         auto id = MailUtils::idForCalendar(account->id(), path);
+        seenIds.insert(id);
 
         // Extract calendar metadata
         auto color = calendarSetDoc->nodeContentAtXPath(".//ical:calendar-color/text()", node);
@@ -1669,6 +1684,38 @@ void DAVWorker::runCalendars() {
                  writableNames.size(), readOnlyNames.size(), noPrivilegeSetNames.size());
     for (auto & n : readOnlyNames) {
         logger->info("  read-only: {}", n);
+    }
+
+    /*
+     Drop calendars the server no longer lists, and their events.
+
+     Nothing removed them before: `local` was read and then only ever used to look calendars
+     up, so a calendar deleted or unshared in Google stayed in the sidebar indefinitely, and
+     its events stayed in range queries - counting towards conflicts and free/busy for a
+     calendar the user cannot see any more.
+
+     Guarded on having seen at least one calendar. Reaching here already means the multistatus
+     parsed, since every failure path above returns early, but pruning against an empty result
+     would erase every calendar on the account and re-download them, so the cheap check earns
+     its place.
+     */
+    if (!seenIds.empty()) {
+        for (auto & pair : local) {
+            if (seenIds.count(pair.first)) {
+                continue;
+            }
+            auto events = store->findAll<Event>(Query().equal("calendarId", pair.first));
+            {
+                MailStoreTransaction transaction{store, "pruneCalendar"};
+                for (auto & event : events) {
+                    store->remove(event.get());
+                }
+                store->remove(pair.second.get());
+                transaction.commit();
+            }
+            logger->info("Removed calendar '{}' and its {} events; the server no longer lists it",
+                         pair.second->name(), events.size());
+        }
     }
 }
 

--- a/MailSync/DAVWorker.cpp
+++ b/MailSync/DAVWorker.cpp
@@ -1423,6 +1423,11 @@ static bool calendarIsWritable(shared_ptr<DavXML> doc, xmlNodePtr responseNode, 
     return writable;
 }
 
+static string lowercased(string value) {
+    transform(value.begin(), value.end(), value.begin(), ::tolower);
+    return value;
+}
+
 /*
  Whether this calendar belongs to the account we are syncing, rather than being one somebody
  else has shared with it.
@@ -1452,8 +1457,14 @@ static string calendarOwnership(shared_ptr<DavXML> doc, xmlNodePtr responseNode,
     // account's own calendar is the principal path with "/user" appended - the Gmail branch
     // synthesises calPrincipal without it. On a server we discovered properly,
     // cachedCalPrincipalPath is the real DAV:current-user-principal and matches outright.
-    const string normalized = normalizeHref(owner);
-    const bool mine = normalized == principalPath || normalized == principalPath + "/user";
+    // Case-folded on both sides: principalPath is built from the address as the user typed
+    // it when adding the account, while the server echoes back whatever case it stores, so
+    // an account added as "Alice@Gmail.com" would otherwise match nothing and every calendar
+    // on it would be marked as somebody else's - which silently disables scheduling with no
+    // failure to see. TaskProcessor compares attendee addresses the same way.
+    const string normalized = lowercased(normalizeHref(owner));
+    const string principal = lowercased(principalPath);
+    const bool mine = normalized == principal || normalized == principal + "/user";
     return mine ? "mine" : "other";
 }
 
@@ -2490,14 +2501,33 @@ void DAVWorker::deleteEvent(shared_ptr<Event> event) {
         href = hrefForNewEvent(calendar->path(), event);
     }
 
+    // 3. A master and each of its RECURRENCE-ID exceptions are separate rows that share one
+    // href, because runForCalendar creates a row per VEVENT in the resource. DELETE removes
+    // the resource, so deleting an exception this way would take the whole series with it -
+    // on a real account 27 resources hold more than one row and the largest holds 22. Refuse
+    // rather than destroy. Deleting the master is still a DELETE: removing the series is
+    // what that means. Removing one occurrence belongs in a PUT that drops the overriding
+    // VEVENT and adds an EXDATE, which is how the client's "this occurrence" path already
+    // does it.
+    if (!event->recurrenceId().empty()) {
+        auto siblings = store->findAll<Event>(
+            Query().equal("calendarId", event->calendarId()).equal("icsuid", event->icsUID()));
+        if (siblings.size() > 1) {
+            throw SyncException("shared-resource",
+                                "Cannot delete a single occurrence by removing its calendar "
+                                "resource; the rest of the series shares it",
+                                false);
+        }
+    }
+
     string calendarUrl = resolvedCalendarURL(calendar->path());
     string fullUrl = replacePath(calendarUrl, href);
 
-    // 3. Perform DELETE request with If-Match header if we have an etag
+    // 4. Perform DELETE request with If-Match header if we have an etag
     string existingEtag = event->etag();
     performICSRequest(fullUrl, "DELETE", "", existingEtag);
 
-    // 4. Remove from local database, only now that the server has accepted
+    // 5. Remove from local database, only now that the server has accepted
     store->remove(event.get());
     logger->info("Event deleted successfully: {}", href);
 }

--- a/MailSync/DAVWorker.hpp
+++ b/MailSync/DAVWorker.hpp
@@ -48,6 +48,10 @@ class DAVWorker {
     // In-memory discovery cache for CalDAV
     bool calendarsDiscoveryComplete = false;
     string cachedCalendarHomeURL = "";
+    // The DAV:href of this account's own principal, retained from discovery so that
+    // runCalendars() can compare it against each calendar's DAV:owner. Empty when the
+    // server named no principal, which leaves ownership unknown rather than wrong.
+    string cachedCalPrincipalPath = "";
 
     bool validateCachedAddressBook();
 

--- a/MailSync/MailStore.cpp
+++ b/MailSync/MailStore.cpp
@@ -149,10 +149,17 @@ void MailStore::recomputeEventTimes() {
             if (cal.Events.empty()) continue;
 
             // One file holds the master and its exceptions; match the VEVENT this row is.
+            // The UID is part of the identity: a resource can hold unrelated events, and two
+            // masters both carry an empty RECURRENCE-ID, so matching on that alone would give
+            // every one of them the first master's times.
             string rid = data.count("rid") ? data["rid"].get<string>() : "";
+            string uid = data.count("icsuid") ? data["icsuid"].get<string>() : "";
             ICalendarEvent * match = nullptr;
             for (auto e : cal.Events) {
-                if (e->RecurrenceId == rid) { match = e; break; }
+                if (e->RecurrenceId != rid) continue;
+                if (!uid.empty() && !e->UID.empty() && e->UID != uid) continue;
+                match = e;
+                break;
             }
             if (!match) match = cal.Events.front();
             if (match->DtStart.IsEmpty()) continue;

--- a/MailSync/MailStore.cpp
+++ b/MailSync/MailStore.cpp
@@ -15,6 +15,8 @@
 #include "SyncException.hpp"
 #include "constants.h"
 
+#include "Event.hpp"
+#include "icalendar.h"
 #include "Folder.hpp"
 #include "Message.hpp"
 #include "Thread.hpp"
@@ -100,9 +102,79 @@ MailStore::MailStore() :
     SQLite::Statement(_db, "PRAGMA main.synchronous = NORMAL").exec();
 }
 
-static int CURRENT_VERSION = 9;
+static int CURRENT_VERSION = 10;
 static string VACUUM_TIME_KEY = "VACUUM_TIME";
 static time_t VACUUM_INTERVAL = 30 * 24 * 60 * 60; // 30 days
+
+/*
+ Rebuilds every event's cached start and end from its stored ICS.
+
+ Those values are written only when an event is fetched, and fetches are gated on ctag and
+ etag, so an event unchanged on the server is never recomputed. A correction to how an ICS
+ timestamp is read would otherwise apply to newly fetched events alone, leaving the table
+ holding two conventions at once and the calendar's range queries selecting across both.
+
+ The indexed recurrenceStart/recurrenceEnd columns are what those queries read, so they are
+ rewritten alongside the data blob; updating the blob by itself would change nothing that is
+ actually queried.
+*/
+void MailStore::recomputeEventTimes() {
+    vector<pair<string, string>> rows;
+    {
+        SQLite::Statement events(_db, "SELECT id, data FROM Event");
+        while (events.executeStep()) {
+            rows.push_back({events.getColumn("id").getString(), events.getColumn("data").getString()});
+        }
+    }
+    if (rows.empty()) {
+        return;
+    }
+
+    cout << "\nRunning Migration";
+    cout.flush();
+
+    // One transaction for the batch: a separate implicit one per row would fsync thousands
+    // of times on a calendar of any size.
+    MailStoreTransaction transaction{this, "recomputeEventTimes"};
+    SQLite::Statement update(
+        _db, "UPDATE Event SET data = ?, recurrenceStart = ?, recurrenceEnd = ? WHERE id = ?");
+
+    for (auto & row : rows) {
+        json data;
+        int start = 0;
+        int end = 0;
+        try {
+            data = json::parse(row.second);
+            ICalendar cal(data.count("ics") ? data["ics"].get<string>() : "");
+            if (cal.Events.empty()) continue;
+
+            // One file holds the master and its exceptions; match the VEVENT this row is.
+            string rid = data.count("rid") ? data["rid"].get<string>() : "";
+            ICalendarEvent * match = nullptr;
+            for (auto e : cal.Events) {
+                if (e->RecurrenceId == rid) { match = e; break; }
+            }
+            if (!match) match = cal.Events.front();
+            if (match->DtStart.IsEmpty()) continue;
+
+            start = match->DtStart.toUnix();
+            end = endOf(match).toUnix();
+            data["rs"] = start;
+            data["re"] = end;
+        } catch (...) {
+            continue; // an unreadable row is left as it stands rather than blocking startup
+        }
+
+        update.reset();
+        update.clearBindings();
+        update.bind(1, data.dump());
+        update.bind(2, start);
+        update.bind(3, end);
+        update.bind(4, row.first);
+        update.exec();
+    }
+    transaction.commit();
+}
 
 void MailStore::migrate() {
     SQLite::Statement uv(_db, "PRAGMA user_version");
@@ -154,6 +226,9 @@ void MailStore::migrate() {
         for (string sql : V9_SETUP_QUERIES) {
             SQLite::Statement(_db, sql).exec();
         }
+    }
+    if (version < 10) {
+        recomputeEventTimes();
     }
 
     // Update the version flag. Note that we don't want to go from v3 back to v2

--- a/MailSync/MailStore.hpp
+++ b/MailSync/MailStore.hpp
@@ -78,6 +78,9 @@ public:
 
     void migrate();
 
+    /** Rebuilds cached event start/end times from stored ICS. See the definition. */
+    void recomputeEventTimes();
+
     SQLite::Database & db();
 
     void resetForAccount(string accountId);

--- a/MailSync/Models/Calendar.cpp
+++ b/MailSync/Models/Calendar.cpp
@@ -95,6 +95,14 @@ void Calendar::setReadOnly(bool readOnly) {
     _data["read_only"] = readOnly;
 }
 
+string Calendar::ownership() {
+    return _data.count("owner") ? _data["owner"].get<string>() : "";
+}
+
+void Calendar::setOwnership(string ownership) {
+    _data["owner"] = ownership;
+}
+
 int Calendar::order() {
     return _data.count("order") ? _data["order"].get<int>() : 0;
 }

--- a/MailSync/Models/Calendar.hpp
+++ b/MailSync/Models/Calendar.hpp
@@ -52,6 +52,11 @@ public:
     bool readOnly();
     void setReadOnly(bool readOnly);
 
+    // "mine" when DAV:owner named this account's own principal, "other" when it named
+    // somebody else's, and "" when the server didn't say. See calendarOwnership().
+    string ownership();
+    void setOwnership(string ownership);
+
     int order();
     void setOrder(int order);
 

--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -501,6 +501,27 @@ void TaskProcessor::performLocal(Task * task) {
     store->save(task);
 }
 
+/*
+ Break a base64 body into CRLF-terminated lines.
+
+ mailcore's base64String() emits one unbroken line (MCEncodeBase64 in
+ Vendor/mailcore2/src/core/basetypes/MCBase64.c writes no line breaks at all), which exceeds
+ RFC 2045 section 6.8's 76-character limit and, past about 740 input bytes, RFC 5321's
+ 1000-octet line limit. A counter-proposal carries the full guest list plus the user's own
+ note, so it reaches that length easily, and an MTA enforcing the limit is entitled to refuse
+ or truncate the message.
+ */
+static string base64Wrapped(const string & encoded) {
+    const size_t width = 76;
+    string out;
+    out.reserve(encoded.size() + (encoded.size() / width + 1) * 2);
+    for (size_t i = 0; i < encoded.size(); i += width) {
+        out += encoded.substr(i, width);
+        out += "\r\n";
+    }
+    return out;
+}
+
 // PerformRemote is run from the foreground worker
 
 void TaskProcessor::performRemote(Task * task) {
@@ -1306,8 +1327,29 @@ void TaskProcessor::performRemoteDestroyEvent(Task * task) {
     }
 
     auto dav = make_shared<DAVWorker>(account);
+    // One event that cannot be deleted must not strand the rest: performLocalDestroyEvent is
+    // deliberately a no-op, so this loop is the only thing that removes any of these rows.
+    // A 404 or 410 means the resource is already gone, which is the outcome asked for - drop
+    // the local row and carry on rather than failing the batch.
+    vector<string> failures {};
     for (auto & event : events) {
-        dav->deleteEvent(event);
+        try {
+            dav->deleteEvent(event);
+        } catch (SyncException & ex) {
+            if (ex.key.find("404") != string::npos || ex.key.find("410") != string::npos) {
+                logger->info("Event {} was already gone from the server; removing locally", event->id());
+                store->remove(event.get());
+                continue;
+            }
+            logger->error("Could not delete event {}: {}", event->id(), ex.toJSON().dump());
+            failures.push_back(event->id());
+        }
+    }
+    if (!failures.empty()) {
+        throw SyncException("delete-failed",
+                            "Could not delete " + to_string(failures.size()) + " of " +
+                                to_string(events.size()) + " events",
+                            false);
     }
 }
 
@@ -2337,7 +2379,8 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
     // is already what the calendar part below uses.
     mimeBody << "Content-Transfer-Encoding: base64\r\n";
     mimeBody << "\r\n";
-    mimeBody << AS_MCSTR(humanReadableText)->dataUsingEncoding("utf-8")->base64String()->UTF8Characters() << "\r\n";
+    mimeBody << base64Wrapped(
+        AS_MCSTR(humanReadableText)->dataUsingEncoding("utf-8")->base64String()->UTF8Characters());
     mimeBody << "\r\n";
     mimeBody << "--" << boundary << "\r\n";
     // Critical: Content-Type MUST include the method parameter (RFC 6047 Section 2.4), and
@@ -2347,7 +2390,7 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
     // Use inline disposition, not attachment (RFC 6047 Section 2.4)
     mimeBody << "Content-Disposition: inline; filename=\"invite.ics\"\r\n";
     mimeBody << "\r\n";
-    mimeBody << icsBase64->UTF8Characters() << "\r\n";
+        mimeBody << base64Wrapped(icsBase64->UTF8Characters());
     mimeBody << "--" << boundary << "--\r\n";
 
     // Build the complete message by getting headers and appending our body

--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -1235,8 +1235,6 @@ void TaskProcessor::performLocalSyncbackEvent(Task * task) {
         store->save(existing.get());
         task->data()["event"]["id"] = existing->id();
     } else {
-        // CREATE: Generate new event with temporary ID
-        string tempId = MailUtils::idRandomlyGenerated();
         string icsData = eventJSON["ics"].get<string>();
         ICalendar cal(icsData);
 
@@ -1244,14 +1242,27 @@ void TaskProcessor::performLocalSyncbackEvent(Task * task) {
             throw SyncException("invalid-ics", "ICS data does not contain any events", false);
         }
 
-        // For new event creation, use the first VEVENT (typically only one)
-        // The Event constructor now handles recurrenceId from the ICalendarEvent
         auto icsEvent = cal.Events.front();
-        Event event("", account->id(), calendarId, icsData, icsEvent);
-        event._data["id"] = tempId;  // Temporary ID until server assigns etag
-        store->save(&event);
 
-        task->data()["event"]["id"] = tempId;
+        // The client picks its own id for an event it has just composed, so a create can name
+        // an event the calendar already holds - answering an invitation that has already
+        // synced down, for one. Reconcile on UID and RECURRENCE-ID within the calendar, as
+        // runForCalendar() does, so that lands as an update rather than an insert against an
+        // id the Event constructor derives from those same fields.
+        auto byUID = store->find<Event>(Query()
+                                            .equal("calendarId", calendarId)
+                                            .equal("icsuid", icsEvent->UID)
+                                            .equal("recurrenceId", icsEvent->RecurrenceId));
+        if (byUID) {
+            byUID->applyICSEventData(byUID->etag(), byUID->href(), icsData, icsEvent);
+            store->save(byUID.get());
+            task->data()["event"]["id"] = byUID->id();
+        } else {
+            Event event("", account->id(), calendarId, icsData, icsEvent);
+            store->save(&event);
+            // Hand the id back: the client composed the event without knowing it.
+            task->data()["event"]["id"] = event.id();
+        }
     }
 
     store->save(task);
@@ -1270,14 +1281,11 @@ void TaskProcessor::performRemoteSyncbackEvent(Task * task) {
 }
 
 void TaskProcessor::performLocalDestroyEvent(Task * task) {
-    vector<string> eventIds {};
-    for (json & e : task->data()["events"]) {
-        eventIds.push_back(e["id"].get<string>());
-    }
-
-    // Mark events as hidden locally (they'll be fully removed after remote delete succeeds)
-    // Note: Unlike contacts, we don't have a "hidden" field on events, so we just
-    // leave them in place until performRemote completes.
+    // Nothing to do locally. Removing the rows here would mean the calendar updated a moment
+    // sooner, at the cost of a delete that cannot be undone if the server refuses it: the
+    // collection's ctag is unchanged by a failed DELETE, so runCalendars() skips it and no
+    // later sync restores what was removed. The rows go in performRemote once the server has
+    // accepted, and DestroyEventTask refreshes the calendar on success.
 }
 
 void TaskProcessor::performRemoteDestroyEvent(Task * task) {
@@ -1287,13 +1295,16 @@ void TaskProcessor::performRemoteDestroyEvent(Task * task) {
     }
 
     auto events = store->findLargeSet<Event>("id", eventIds);
-    auto dav = make_shared<DAVWorker>(account);
+    if (events.size() != eventIds.size()) {
+        logger->warn("Destroying {} of {} requested events; the rest are no longer present",
+                     events.size(), eventIds.size());
+    }
 
+    auto dav = make_shared<DAVWorker>(account);
     for (auto & event : events) {
         dav->deleteEvent(event);
     }
 }
-
 
 void TaskProcessor::performLocalSyncbackCategory(Task * task) {
     
@@ -2162,13 +2173,23 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
         ? task->data()["icsRSVPStatus"].get<string>()
         : "ACCEPTED";
 
+    // The iTIP method being sent to the organizer. REPLY answers the invitation; COUNTER
+    // proposes a different time (RFC 5546 section 3.2.7). Absent means REPLY, so a client
+    // older than counter-proposal support keeps working unchanged.
+    string method = task->data().count("method")
+        ? task->data()["method"].get<string>()
+        : "REPLY";
+    if (method != "REPLY" && method != "COUNTER") {
+        throw SyncException("invalid-ics", "Unsupported iTIP method: " + method, false);
+    }
+
     // =========================================================================
     // RFC 5546/6047 Validation
     // =========================================================================
 
-    // Validation 1: Check ICS contains METHOD:REPLY (RFC 5546 requirement)
-    if (ics.find("METHOD:REPLY") == string::npos) {
-        throw SyncException("invalid-ics", "ICS data must contain METHOD:REPLY for an RSVP response", false);
+    // Validation 1: the ICS must declare the method we're sending it as (RFC 5546)
+    if (ics.find("METHOD:" + method) == string::npos) {
+        throw SyncException("invalid-ics", "ICS data must contain METHOD:" + method, false);
     }
 
     // Parse the ICS to validate and extract event information
@@ -2183,34 +2204,46 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
     // Validation 2: UID is required (RFC 5546 Section 3.2.3 - MUST match original REQUEST)
     if (event->UID.empty()) {
         throw SyncException("invalid-ics",
-            "ICS REPLY must contain UID property matching the original invitation", false);
+            "ICS " + method + " must contain UID property matching the original invitation", false);
     }
 
     // Validation 3: DTSTAMP is required (RFC 5546 Section 3.2.3)
     if (event->DtStamp.IsEmpty()) {
         throw SyncException("invalid-ics",
-            "ICS REPLY must contain DTSTAMP property", false);
+            "ICS " + method + " must contain DTSTAMP property", false);
     }
 
     // Validation 4: ORGANIZER is required (RFC 5546 Section 3.2.3)
     if (event->Organizer.empty()) {
         throw SyncException("invalid-ics",
-            "ICS REPLY must contain ORGANIZER property", false);
+            "ICS " + method + " must contain ORGANIZER property", false);
     }
 
-    // Validation 5: REPLY must contain exactly one ATTENDEE (RFC 5546 Section 3.2.3)
-    if (event->Attendees.size() != 1) {
+    // Validation 5: a REPLY carries exactly one ATTENDEE, the person replying (RFC 5546
+    // Section 3.2.3). A COUNTER carries the proposing attendee and may repeat the rest of
+    // the guest list, so it only needs at least one (Section 3.2.7).
+    if (method == "REPLY" && event->Attendees.size() != 1) {
         throw SyncException("invalid-ics",
             "ICS REPLY must contain exactly one ATTENDEE (the replying user), found " + to_string(event->Attendees.size()), false);
     }
-
-    // Validation 6: Check ATTENDEE has valid PARTSTAT (RFC 5545 Section 3.2.12)
-    bool hasValidPartstat = (ics.find("PARTSTAT=ACCEPTED") != string::npos ||
-                             ics.find("PARTSTAT=DECLINED") != string::npos ||
-                             ics.find("PARTSTAT=TENTATIVE") != string::npos);
-    if (!hasValidPartstat) {
+    if (method == "COUNTER" && event->Attendees.empty()) {
         throw SyncException("invalid-ics",
-            "ATTENDEE must have valid PARTSTAT parameter (ACCEPTED, DECLINED, or TENTATIVE)", false);
+            "ICS COUNTER must contain the ATTENDEE making the proposal", false);
+    }
+
+    // Validation 6: a REPLY states a participation status (RFC 5545 Section 3.2.12); a
+    // COUNTER states a time instead, so it needs DTSTART rather than a PARTSTAT.
+    if (method == "REPLY") {
+        bool hasValidPartstat = (ics.find("PARTSTAT=ACCEPTED") != string::npos ||
+                                 ics.find("PARTSTAT=DECLINED") != string::npos ||
+                                 ics.find("PARTSTAT=TENTATIVE") != string::npos);
+        if (!hasValidPartstat) {
+            throw SyncException("invalid-ics",
+                "ATTENDEE must have valid PARTSTAT parameter (ACCEPTED, DECLINED, or TENTATIVE)", false);
+        }
+    } else if (event->DtStart.IsEmpty()) {
+        throw SyncException("invalid-ics",
+            "ICS COUNTER must contain the proposed DTSTART", false);
     }
 
     // Extract attendee email for From address validation
@@ -2248,7 +2281,15 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
 
     // Generate human-readable text based on RSVP status (per RFC 6047 recommendation)
     string humanReadableText;
-    if (icsRSVPStatus == "ACCEPTED") {
+    if (method == "COUNTER") {
+        humanReadableText = fromEmail + " proposed a new time for: " + eventSummary;
+        if (task->data().count("comment")) {
+            string comment = task->data()["comment"].get<string>();
+            if (!comment.empty()) {
+                humanReadableText += "\r\n\r\n" + comment;
+            }
+        }
+    } else if (icsRSVPStatus == "ACCEPTED") {
         humanReadableText = fromEmail + " has accepted the invitation to: " + eventSummary;
     } else if (icsRSVPStatus == "DECLINED") {
         humanReadableText = fromEmail + " has declined the invitation to: " + eventSummary;
@@ -2259,7 +2300,7 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
     }
 
     // Generate a unique boundary for multipart message
-    string boundary = "----=_Mailspring_RSVP_" + to_string(time(0)) + "_" + to_string(rand());
+    string boundary = "----=_Mailspring_" + method + "_" + to_string(time(0)) + "_" + to_string(rand());
 
     // Base64 encode the ICS data (RFC 6047 recommends base64 for maximum compatibility)
     Data * icsData = AS_MCSTR(ics)->dataUsingEncoding("utf-8");
@@ -2284,13 +2325,19 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
     stringstream mimeBody;
     mimeBody << "--" << boundary << "\r\n";
     mimeBody << "Content-Type: text/plain; charset=UTF-8\r\n";
-    mimeBody << "Content-Transfer-Encoding: 7bit\r\n";
+    // Base64, not 7bit: this part carries the event's summary and the user's own note, both
+    // UTF-8 and both routinely non-ASCII - an accented name is enough. Declaring 7bit over
+    // 8-bit bytes violates RFC 2045 section 6.2, and a relay without the 8BITMIME extension
+    // (RFC 6152) is entitled to mangle or refuse it. Base64 is 7-bit clean on every path and
+    // is already what the calendar part below uses.
+    mimeBody << "Content-Transfer-Encoding: base64\r\n";
     mimeBody << "\r\n";
-    mimeBody << humanReadableText << "\r\n";
+    mimeBody << AS_MCSTR(humanReadableText)->dataUsingEncoding("utf-8")->base64String()->UTF8Characters() << "\r\n";
     mimeBody << "\r\n";
     mimeBody << "--" << boundary << "\r\n";
-    // Critical: Content-Type MUST include method=REPLY parameter (RFC 6047 Section 2.4)
-    mimeBody << "Content-Type: text/calendar; method=REPLY; charset=UTF-8\r\n";
+    // Critical: Content-Type MUST include the method parameter (RFC 6047 Section 2.4), and
+    // it MUST agree with the METHOD inside the ICS or receiving calendars discard it.
+    mimeBody << "Content-Type: text/calendar; method=" << method << "; charset=UTF-8\r\n";
     mimeBody << "Content-Transfer-Encoding: base64\r\n";
     // Use inline disposition, not attachment (RFC 6047 Section 2.4)
     mimeBody << "Content-Disposition: inline; filename=\"invite.ics\"\r\n";
@@ -2351,7 +2398,7 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
     SMTPProgress sprogress;
     MailUtils::configureSessionForAccount(smtp, account);
 
-    logger->info("-- Sending RFC 6047-compliant RSVP ({}) to organizer {}", icsRSVPStatus, organizer);
+    logger->info("-- Sending RFC 6047-compliant {} ({}) to organizer {}", method, icsRSVPStatus, organizer);
     smtp.sendMessage(messageData, &sprogress, &err);
 
     if (err != ErrorNone) {
@@ -2361,5 +2408,5 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
         throw SyncException("send-failed", ErrorCodeToTypeMap[err], false);
     }
 
-    logger->info("-- RSVP sent successfully");
+    logger->info("-- {} sent successfully", method);
 }

--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -1294,10 +1294,15 @@ void TaskProcessor::performRemoteDestroyEvent(Task * task) {
         eventIds.push_back(e["id"].get<string>());
     }
 
+    // findLargeSet chunks through MailUtils::chunksOfVector, which erases from the vector it
+    // is handed, so eventIds is empty once the lookup returns. Read the count before the call
+    // or this compares against zero and warns on every successful delete.
+    const size_t requested = eventIds.size();
+
     auto events = store->findLargeSet<Event>("id", eventIds);
-    if (events.size() != eventIds.size()) {
+    if (events.size() != requested) {
         logger->warn("Destroying {} of {} requested events; the rest are no longer present",
-                     events.size(), eventIds.size());
+                     events.size(), requested);
     }
 
     auto dav = make_shared<DAVWorker>(account);

--- a/MailSync/main.cpp
+++ b/MailSync/main.cpp
@@ -232,16 +232,29 @@ void runCalContactsSyncWorker() {
     std::this_thread::sleep_for(std::chrono::seconds(15 + davWorker->account->startDelay()));
 
     // BG Note: This process does not use MailUtils::sleepWorkerUntilWakeOrSec(), which means
-    // cal + contact sync runs every 15 minutes regardless of how often you slam on the Sync Mail
-    // icon. I am trying to narrow down why we are hitting the Google Calendar + People API limits
-    // so quickly (in almost exactly 8 hours after the 2AM reset each day).
+    // cal + contact sync runs on a fixed cadence regardless of how often you slam on the Sync
+    // Mail icon. I am trying to narrow down why we are hitting the Google Calendar + People API
+    // limits so quickly (in almost exactly 8 hours after the 2AM reset each day).
 
-    while(true) {
+    // Calendars poll more often than contacts: an unchanged calendar usually costs one
+    // PROPFIND because runCalendars() compares ctags before fetching anything, while contact
+    // sync has no such early-out and on Gmail spends the People API quota the note above
+    // concerns. Servers that omit ctag re-list every calendar per pass, which is why this is
+    // minutes rather than seconds; editing an event refreshes on demand regardless.
+    const auto calendarInterval = std::chrono::minutes(15);
+    const int calendarCyclesPerContactSync = 5; // contacts every 5th calendar pass
+
+    for (int cycle = 0; ; cycle++) {
         try {
-            if (contactsWorker) {
+            bool syncContacts = (cycle % calendarCyclesPerContactSync == 0);
+            if (contactsWorker && syncContacts) {
                 contactsWorker->run();
             }
-            davWorker->run();
+            if (syncContacts) {
+                davWorker->run();
+            } else {
+                davWorker->runCalendars();
+            }
         } catch (SyncException & ex) {
             exceptions::logCurrentExceptionWithStackTrace();
 
@@ -273,7 +286,7 @@ void runCalContactsSyncWorker() {
             return;
             // abort();
         }
-        std::this_thread::sleep_for(std::chrono::minutes(45));
+        std::this_thread::sleep_for(calendarInterval);
     }
 }
 
@@ -778,8 +791,16 @@ void runListenOnMainThread(shared_ptr<Account> account) {
                 if (runningCalendarSync.compare_exchange_strong(expected, true)) {
                     std::thread([account]() {
                         SetThreadName("calendar");
-                        auto worker = DAVWorker(account);
-                        worker.run();
+                        try {
+                            // Calendars only: contact sync spends a separate, scarcer API
+                            // quota and has no ctag early-out, so it keeps its own cadence
+                            // rather than riding every manual calendar refresh.
+                            DAVWorker(account).runCalendars();
+                        } catch (...) {
+                            // A refresh failing must not take the process down; the periodic
+                            // worker retries on its own schedule.
+                            exceptions::logCurrentExceptionWithStackTrace();
+                        }
                         runningCalendarSync = false;
                     }).detach();
                 }

--- a/Vendor/icalendarlib/date.cpp
+++ b/Vendor/icalendarlib/date.cpp
@@ -23,12 +23,20 @@ Date &Date::operator =(const string &Text) {
 		if (Text.length() >= 15) {
 			sscanf(Text.c_str()+9, "%2hd%2hd%2hd", &Data[HOUR], &Data[MINUTE], &Data[SECOND]);
 			WithTime = true;
+			// A trailing "Z" makes the value UTC (RFC 5545 section 3.3.5); toUnix() needs it.
+			// Scan back over trailing whitespace: GetSubProperty() hands over RRULE parts such
+			// as UNTIL with the line's carriage return still attached, unlike GetProperty().
+			size_t last = Text.find_last_not_of(" \t\r\n");
+			IsUTC = (last != string::npos && (Text[last] == 'Z' || Text[last] == 'z'));
 		} else {
 			Data[HOUR] = Data[MINUTE] = Data[SECOND] = 0;
 			WithTime = false;
+			IsUTC = false;
 		}
-	} else
+	} else {
 		Data[YEAR] = Data[MONTH] = Data[DAY] = 0;
+		IsUTC = false;
+	}
 	return *this;
 }
 
@@ -128,6 +136,7 @@ void Date::SetToNow() {
 	Data[SECOND] = CurrentTime->tm_sec;
 	
 	WithTime = true;
+	IsUTC = false; // localtime() above gives a local wall-clock, not a UTC one
 }
 
 Date::DatePart &Date::DatePart::operator +=(short Value) {

--- a/Vendor/icalendarlib/date.h
+++ b/Vendor/icalendarlib/date.h
@@ -33,6 +33,14 @@ public:
 		Clear();
 	}
 	
+    /*
+     An iCalendar DATE-TIME is one of three things (RFC 5545 section 3.3.5): UTC when it ends
+     in "Z", a wall-clock time in a named zone when the property carries TZID, or floating.
+     Only UTC is unambiguous here, so only UTC uses timegm(); the other two resolve against
+     the local zone, which is correct for a floating time and for a TZID matching this
+     machine. tm_isdst is -1 so the C library determines daylight saving rather than assuming
+     standard time, which is an hour out for half the year.
+    */
     int toUnix() {
         struct tm timeinfo {};
         memset(&timeinfo, 0, sizeof(struct tm));
@@ -40,6 +48,14 @@ public:
         sprintf(Temp, "%.4d%.2d%.2dT%.2d%.2d%.2d", Data[YEAR], Data[MONTH], Data[DAY], Data[HOUR], Data[MINUTE], Data[SECOND]);
         std::istringstream ss(Temp);
         ss >> std::get_time(&timeinfo, "%Y%m%dT%H%M%S");
+        timeinfo.tm_isdst = -1; // let the C library work out DST for local times
+        if (IsUTC) {
+#ifdef _MSC_VER
+            return (int)_mkgmtime(&timeinfo);
+#else
+            return (int)timegm(&timeinfo);
+#endif
+        }
         return (int)mktime(&timeinfo);
     }
 
@@ -88,9 +104,12 @@ public:
 		
 		Data[HOUR] = Data[MINUTE] = Data[SECOND] = 0;
 		WithTime = false;
+		IsUTC = false;
 	}
 	
 	bool WithTime;
+	/** True when the value was written in UTC, i.e. ended in "Z". */
+	bool IsUTC;
 };
 
 class Date::DatePart {


### PR DESCRIPTION
Calendar scheduling support in the sync engine: iTIP `COUNTER`, calendar ownership, and UTC
time correctness. This is the engine half of calendar scheduling; the client half depends on
it, because a client that sends `METHOD:COUNTER` is rejected outright by any engine whose
`performRemoteSendRSVP` still looks for `METHOD:REPLY`.

Rebased onto master now that #122 has landed, so this is calendar-only — 10 files rather than
the 16 it carried before. Everything this branch no longer touches is byte-identical to
master.

### What it does

- **iTIP `COUNTER`** — an attendee can propose a different time. `performRemoteSendRSVP`
  accepts `COUNTER` alongside `REPLY` instead of rejecting anything that isn't a reply.
- **Calendar ownership** — `DAV:owner` is resolved against the principal URL so the engine
  knows which calendars are the user's own. Hrefs are compared after normalisation, which
  matters because providers disagree about encoding and trailing slashes.
- **UTC correctness** — `timegm` for the conversions that were going through local time,
  guarded `#ifdef _MSC_VER` to `_mkgmtime` on Windows, matching the precedent already in
  `Vendor/mailcore2/.../MCLibetpan.cpp`.

### Verified

Built and linked clean on Linux (GCC 16.2.1) from this exact commit.

Against a live Google Workspace CalDAV account: the v10 schema migration runs clean on a real
316MB / 841-event database; `DAV:owner` resolves the user's own calendar as `mine` and shared
or resource calendars as `other`; orphaned calendars are pruned on the next discovery pass;
and accepting an emailed invitation works end to end — `PARTSTAT=ACCEPTED` written, `METHOD`
stripped, the generated href accepted, the PUT succeeded, and the iTIP REPLY reached the
organizer with `SEQUENCE` correctly left at 0.

The ownership and href-normalisation logic was additionally extracted into a standalone
harness and compiled against real href shapes from Google (including the `/user` principal
suffix), Fastmail, iCloud and Nextcloud/SabreDAV, covering absolute-vs-path, `%40`,
double-encoded `%2540` and trailing slashes: 19/19. That exercises the URL logic, not the
full PROPFIND discovery flow against those servers — only Google has been exercised live.

macOS and Windows are audited rather than built. Nothing here should need project-file or
build changes on those platforms: `git diff --name-status` has no added files, so no
xcodeproj/vcxproj source list needs touching, and this branch no longer touches
`CMakeLists.txt` at all — the build changes it used to carry went upstream with #122. The one
POSIX-only function introduced, `timegm`, is guarded `#ifdef _MSC_VER` to `_mkgmtime` in
`Vendor/icalendarlib/date.h`, matching the precedent in
`Vendor/mailcore2/.../MCLibetpan.cpp`.
