### PR TITLE
Keep a failing manual calendar refresh from aborting the sync process

### DIFF
--- a/MailSync/main.cpp
+++ b/MailSync/main.cpp
@@ -778,8 +778,16 @@ void runListenOnMainThread(shared_ptr<Account> account) {
                 if (runningCalendarSync.compare_exchange_strong(expected, true)) {
                     std::thread([account]() {
                         SetThreadName("calendar");
-                        auto worker = DAVWorker(account);
-                        worker.run();
+                        try {
+                            // Calendars only: contact sync spends a separate, scarcer API
+                            // quota and has no ctag early-out, so it keeps its own cadence
+                            // rather than riding every manual calendar refresh.
+                            DAVWorker(account).runCalendars();
+                        } catch (...) {
+                            // A refresh failing must not take the process down; the periodic
+                            // worker retries on its own schedule.
+                            exceptions::logCurrentExceptionWithStackTrace();
+                        }
                         runningCalendarSync = false;
                     }).detach();
                 }


### PR DESCRIPTION
The "sync-calendar" stdin command - what the client sends for Refresh
Calendars and after every event write - ran DAVWorker::run() on a detached
thread with no exception handler. Any SyncException out of the refresh, a
server returning 500 for one PROPFIND being enough, reached std::terminate
and took the whole sync process down with it, mail sync included. The
periodic worker in runCalContactsSyncWorker() catches the same exceptions
and carries on; the manual path never did.

The refresh thread now catches and logs, and the periodic worker's next pass
retries as before. It also syncs calendars only: DAVWorker::run() includes
CardDAV, and on Gmail contact sync spends the People API quota the note in
runCalContactsSyncWorker() is concerned about, so it stays on its own cadence
rather than riding along every time the user presses Refresh or saves an
event.

Verified against a scriptable CalDAV server, sending "sync-calendar" over
stdin to master and to this branch:

    server healthy    master: full CardDAV discovery, then calendars
                      branch: calendars only
    server answers    master: process exits with SIGABRT
      500             branch: exception logged, process continues

One of the single-concern pieces of #123, which this supersedes in part.

Client side: Foundry376/Mailspring#2853 (merged 2026-09-04) made the Refresh Calendars menu item send exactly this command, and the client already sent it after every event write (`SyncbackEventTask` and `DestroyEventTask` call `Actions.syncCalendarNow`), so the released client reaches this path on every save and every press of Refresh.

### CI

Runs from a fork wait for approval here, so these ran fork-internally on the same commit:

- Linux x64 and arm64: https://github.com/brhellman/Mailspring-Sync/actions/runs/34476187066
- Windows: https://github.com/brhellman/Mailspring-Sync/actions/runs/34476187068
- macOS (same content plus a fork-only workflow guard, since the fork has no signing certificate): https://github.com/brhellman/Mailspring-Sync/actions/runs/34479252341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
