### PR TITLE
Refuse to delete one occurrence by removing the resource the whole series shares

### DIFF
--- a/MailSync/DAVWorker.cpp
+++ b/MailSync/DAVWorker.cpp
@@ -2333,14 +2333,33 @@ void DAVWorker::deleteEvent(shared_ptr<Event> event) {
         href = hrefForNewEvent(calendar->path(), event);
     }
 
+    // 3. A master and each of its RECURRENCE-ID exceptions are separate rows that share one
+    // href, because runForCalendar creates a row per VEVENT in the resource. DELETE removes
+    // the resource, so deleting an exception this way would take the whole series with it -
+    // on a real account 27 resources hold more than one row and the largest holds 22. Refuse
+    // rather than destroy. Deleting the master is still a DELETE: removing the series is
+    // what that means. Removing one occurrence belongs in a PUT that drops the overriding
+    // VEVENT and adds an EXDATE, which is how the client's "this occurrence" path already
+    // does it.
+    if (!event->recurrenceId().empty()) {
+        auto siblings = store->findAll<Event>(
+            Query().equal("calendarId", event->calendarId()).equal("icsuid", event->icsUID()));
+        if (siblings.size() > 1) {
+            throw SyncException("shared-resource",
+                                "Cannot delete a single occurrence by removing its calendar "
+                                "resource; the rest of the series shares it",
+                                false);
+        }
+    }
+
     string calendarUrl = resolvedCalendarURL(calendar->path());
     string fullUrl = replacePath(calendarUrl, href);
 
-    // 3. Perform DELETE request with If-Match header if we have an etag
+    // 4. Perform DELETE request with If-Match header if we have an etag
     string existingEtag = event->etag();
     performICSRequest(fullUrl, "DELETE", "", existingEtag);
 
-    // 4. Remove from local database
+    // 5. Remove from local database, only now that the server has accepted
     store->remove(event.get());
     logger->info("Event deleted successfully: {}", href);
 }

--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -1270,14 +1270,11 @@ void TaskProcessor::performRemoteSyncbackEvent(Task * task) {
 }
 
 void TaskProcessor::performLocalDestroyEvent(Task * task) {
-    vector<string> eventIds {};
-    for (json & e : task->data()["events"]) {
-        eventIds.push_back(e["id"].get<string>());
-    }
-
-    // Mark events as hidden locally (they'll be fully removed after remote delete succeeds)
-    // Note: Unlike contacts, we don't have a "hidden" field on events, so we just
-    // leave them in place until performRemote completes.
+    // Nothing to do locally. Removing the rows here would mean the calendar updated a moment
+    // sooner, at the cost of a delete that cannot be undone if the server refuses it: the
+    // collection's ctag is unchanged by a failed DELETE, so runCalendars() skips it and no
+    // later sync restores what was removed. The rows go in performRemote once the server has
+    // accepted, and DestroyEventTask refreshes the calendar on success.
 }
 
 void TaskProcessor::performRemoteDestroyEvent(Task * task) {
@@ -1286,14 +1283,43 @@ void TaskProcessor::performRemoteDestroyEvent(Task * task) {
         eventIds.push_back(e["id"].get<string>());
     }
 
-    auto events = store->findLargeSet<Event>("id", eventIds);
-    auto dav = make_shared<DAVWorker>(account);
+    // findLargeSet chunks through MailUtils::chunksOfVector, which erases from the vector it
+    // is handed, so eventIds is empty once the lookup returns. Read the count before the call
+    // or this compares against zero and warns on every successful delete.
+    const size_t requested = eventIds.size();
 
+    auto events = store->findLargeSet<Event>("id", eventIds);
+    if (events.size() != requested) {
+        logger->warn("Destroying {} of {} requested events; the rest are no longer present",
+                     events.size(), requested);
+    }
+
+    auto dav = make_shared<DAVWorker>(account);
+    // One event that cannot be deleted must not strand the rest: performLocalDestroyEvent is
+    // deliberately a no-op, so this loop is the only thing that removes any of these rows.
+    // A 404 or 410 means the resource is already gone, which is the outcome asked for - drop
+    // the local row and carry on rather than failing the batch.
+    vector<string> failures {};
     for (auto & event : events) {
-        dav->deleteEvent(event);
+        try {
+            dav->deleteEvent(event);
+        } catch (SyncException & ex) {
+            if (ex.key.find("404") != string::npos || ex.key.find("410") != string::npos) {
+                logger->info("Event {} was already gone from the server; removing locally", event->id());
+                store->remove(event.get());
+                continue;
+            }
+            logger->error("Could not delete event {}: {}", event->id(), ex.toJSON().dump());
+            failures.push_back(event->id());
+        }
+    }
+    if (!failures.empty()) {
+        throw SyncException("delete-failed",
+                            "Could not delete " + to_string(failures.size()) + " of " +
+                                to_string(events.size()) + " events",
+                            false);
     }
 }
-
 
 void TaskProcessor::performLocalSyncbackCategory(Task * task) {
     


### PR DESCRIPTION
A recurring master and each of its RECURRENCE-ID exceptions are separate Event
rows, but they live in one CalDAV resource - runForCalendar creates a row per
VEVENT in the file. deleteEvent() issued a DELETE on that resource for any row
it was handed, so asking to remove a single moved occurrence removed the
entire series from the server. On a real account 27 resources hold more than
one row and the largest holds 22.

deleteEvent() now refuses, with a "shared-resource" error, to DELETE for an
exception row whose UID has other rows on the same calendar. Deleting the
master is still a DELETE, because removing the series is what that means.
Removing one occurrence belongs in a PUT that drops the overriding VEVENT and
adds an EXDATE, which is how the client already handles "this occurrence".

performRemoteDestroyEvent changes with it:

- Events are deleted one at a time inside a try, so one failure no longer
  strands the rest of a batch. performLocalDestroyEvent is deliberately a
  no-op - a row removed locally before the server accepted could not be
  restored, because a failed DELETE leaves the collection's ctag unchanged
  and the next sync would skip it - so this loop is the only place these
  rows are removed.
- A 404 or 410 means the resource is already gone, which is the outcome the
  user asked for: the local row is dropped and the task succeeds instead of
  failing and leaving a stale event on the calendar.
- The requested count is read before findLargeSet(), which drains the vector
  it is handed through chunksOfVector(); read afterwards it is always zero.

Verified against Radicale with a two-VEVENT resource (weekly series plus one
moved occurrence), master vs this branch, driving DestroyEventTask through the
engine's stdin:

    delete the moved occurrence     master: resource gone from the server,
                                            the whole series with it
                                    branch: task fails "shared-resource",
                                            resource and both rows intact
    delete the master               both:   DELETE issued, resource gone
    delete two events, one already  master: task fails on the 404, the stale
      removed on the server                 row stays
                                    branch: the live one is deleted, the gone
                                            one is dropped locally, task
                                            completes

One of the single-concern pieces of #123, which this supersedes in part.

Client side: Foundry376/Mailspring#2866 (merged 2026-09-17) stopped the client asking for this delete; removing a moved occurrence is now a PUT that cancels it on the master, and the helper's comment names this PR as the engine-side guard. This keeps an older client, or any other path that hands deleteEvent() an exception row, from taking the series with it.

### CI

Runs from a fork wait for approval here, so these ran fork-internally on the same commit:

- Linux x64 and arm64: https://github.com/brhellman/Mailspring-Sync/actions/runs/34476299792
- Windows: https://github.com/brhellman/Mailspring-Sync/actions/runs/34476299903
- macOS (same content plus a fork-only workflow guard, since the fork has no signing certificate): https://github.com/brhellman/Mailspring-Sync/actions/runs/34479262946

🤖 Generated with [Claude Code](https://claude.com/claude-code)
