### PR TITLE
Treat a created event whose UID is already on the calendar as an update

### DIFF
--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -1235,8 +1235,6 @@ void TaskProcessor::performLocalSyncbackEvent(Task * task) {
         store->save(existing.get());
         task->data()["event"]["id"] = existing->id();
     } else {
-        // CREATE: Generate new event with temporary ID
-        string tempId = MailUtils::idRandomlyGenerated();
         string icsData = eventJSON["ics"].get<string>();
         ICalendar cal(icsData);
 
@@ -1244,14 +1242,27 @@ void TaskProcessor::performLocalSyncbackEvent(Task * task) {
             throw SyncException("invalid-ics", "ICS data does not contain any events", false);
         }
 
-        // For new event creation, use the first VEVENT (typically only one)
-        // The Event constructor now handles recurrenceId from the ICalendarEvent
         auto icsEvent = cal.Events.front();
-        Event event("", account->id(), calendarId, icsData, icsEvent);
-        event._data["id"] = tempId;  // Temporary ID until server assigns etag
-        store->save(&event);
 
-        task->data()["event"]["id"] = tempId;
+        // The client picks its own id for an event it has just composed, so a create can name
+        // an event the calendar already holds - answering an invitation that has already
+        // synced down, for one. Reconcile on UID and RECURRENCE-ID within the calendar, as
+        // runForCalendar() does, so that lands as an update rather than an insert against an
+        // id the Event constructor derives from those same fields.
+        auto byUID = store->find<Event>(Query()
+                                            .equal("calendarId", calendarId)
+                                            .equal("icsuid", icsEvent->UID)
+                                            .equal("recurrenceId", icsEvent->RecurrenceId));
+        if (byUID) {
+            byUID->applyICSEventData(byUID->etag(), byUID->href(), icsData, icsEvent);
+            store->save(byUID.get());
+            task->data()["event"]["id"] = byUID->id();
+        } else {
+            Event event("", account->id(), calendarId, icsData, icsEvent);
+            store->save(&event);
+            // Hand the id back: the client composed the event without knowing it.
+            task->data()["event"]["id"] = event.id();
+        }
     }
 
     store->save(task);


### PR DESCRIPTION
The client composes an event without knowing whether the calendar already
holds it. Answering an emailed invitation is the common case: the organizer's
copy has usually synced down by the time the user clicks Accept, so the
SyncbackEventTask arrives as a create for a UID that already has a row.

performLocalSyncbackEvent inserted a second row under a random id for that
UID, and writeAndResyncEvent then PUT the event to "<uid>.ics" while the
synced copy lived at a name the server chose. Servers that enforce UID
uniqueness within a collection - Radicale and SabreDAV answer 409
no-uid-conflict (RFC 4791 section 5.3.2) - rejected the write, so the
acceptance never reached the calendar, and the duplicate row stayed behind.

A create now looks the event up by UID and RECURRENCE-ID within the calendar,
the same identity runForCalendar() uses, and applies the new ICS to the
existing row - keeping its href and etag - when there is one. A genuinely new
event uses the id the Event constructor derives from those same fields
instead of a throwaway random id, and the id is handed back to the client in
the task, since the client did not have one.

Verified against Radicale, master vs this branch: an invitation synced down
with PARTSTAT=NEEDS-ACTION, then a create carrying the same UID with
PARTSTAT=ACCEPTED.

    master:  two Event rows for the UID; PUT to inv-1@lab.test.ics rejected
             with 409 no-uid-conflict; the server still says NEEDS-ACTION
    branch:  one Event row, same id as before; PUT to the existing resource;
             the server now says ACCEPTED

One of the single-concern pieces of #123, which this supersedes in part.

### CI

Runs from a fork wait for approval here, so these ran fork-internally on the same commit:

- Linux x64 and arm64: https://github.com/brhellman/Mailspring-Sync/actions/runs/34476319247
- Windows: https://github.com/brhellman/Mailspring-Sync/actions/runs/34476319317
- macOS (same content plus a fork-only workflow guard, since the fork has no signing certificate): https://github.com/brhellman/Mailspring-Sync/actions/runs/34479292196

🤖 Generated with [Claude Code](https://claude.com/claude-code)