### PR TITLE
Read UTC iCalendar timestamps as UTC instead of local time

### DIFF
--- a/MailSync/MailStore.cpp
+++ b/MailSync/MailStore.cpp
@@ -15,6 +15,8 @@
 #include "SyncException.hpp"
 #include "constants.h"
 
+#include "Event.hpp"
+#include "icalendar.h"
 #include "Folder.hpp"
 #include "Message.hpp"
 #include "Thread.hpp"
@@ -100,9 +102,86 @@ MailStore::MailStore() :
     SQLite::Statement(_db, "PRAGMA main.synchronous = NORMAL").exec();
 }
 
-static int CURRENT_VERSION = 9;
+static int CURRENT_VERSION = 10;
 static string VACUUM_TIME_KEY = "VACUUM_TIME";
 static time_t VACUUM_INTERVAL = 30 * 24 * 60 * 60; // 30 days
+
+/*
+ Rebuilds every event's cached start and end from its stored ICS.
+
+ Those values are written only when an event is fetched, and fetches are gated on ctag and
+ etag, so an event unchanged on the server is never recomputed. A correction to how an ICS
+ timestamp is read would otherwise apply to newly fetched events alone, leaving the table
+ holding two conventions at once and the calendar's range queries selecting across both.
+
+ The indexed recurrenceStart/recurrenceEnd columns are what those queries read, so they are
+ rewritten alongside the data blob; updating the blob by itself would change nothing that is
+ actually queried.
+*/
+void MailStore::recomputeEventTimes() {
+    vector<pair<string, string>> rows;
+    {
+        SQLite::Statement events(_db, "SELECT id, data FROM Event");
+        while (events.executeStep()) {
+            rows.push_back({events.getColumn("id").getString(), events.getColumn("data").getString()});
+        }
+    }
+    if (rows.empty()) {
+        return;
+    }
+
+    cout << "\nRunning Migration";
+    cout.flush();
+
+    // One transaction for the batch: a separate implicit one per row would fsync thousands
+    // of times on a calendar of any size.
+    MailStoreTransaction transaction{this, "recomputeEventTimes"};
+    SQLite::Statement update(
+        _db, "UPDATE Event SET data = ?, recurrenceStart = ?, recurrenceEnd = ? WHERE id = ?");
+
+    for (auto & row : rows) {
+        json data;
+        int start = 0;
+        int end = 0;
+        try {
+            data = json::parse(row.second);
+            ICalendar cal(data.count("ics") ? data["ics"].get<string>() : "");
+            if (cal.Events.empty()) continue;
+
+            // One file holds the master and its exceptions; match the VEVENT this row is.
+            // The UID is part of the identity: a resource can hold unrelated events, and two
+            // masters both carry an empty RECURRENCE-ID, so matching on that alone would give
+            // every one of them the first master's times.
+            string rid = data.count("rid") ? data["rid"].get<string>() : "";
+            string uid = data.count("icsuid") ? data["icsuid"].get<string>() : "";
+            ICalendarEvent * match = nullptr;
+            for (auto e : cal.Events) {
+                if (e->RecurrenceId != rid) continue;
+                if (!uid.empty() && !e->UID.empty() && e->UID != uid) continue;
+                match = e;
+                break;
+            }
+            if (!match) match = cal.Events.front();
+            if (match->DtStart.IsEmpty()) continue;
+
+            start = match->DtStart.toUnix();
+            end = endOf(match).toUnix();
+            data["rs"] = start;
+            data["re"] = end;
+        } catch (...) {
+            continue; // an unreadable row is left as it stands rather than blocking startup
+        }
+
+        update.reset();
+        update.clearBindings();
+        update.bind(1, data.dump());
+        update.bind(2, start);
+        update.bind(3, end);
+        update.bind(4, row.first);
+        update.exec();
+    }
+    transaction.commit();
+}
 
 void MailStore::migrate() {
     SQLite::Statement uv(_db, "PRAGMA user_version");
@@ -154,6 +233,9 @@ void MailStore::migrate() {
         for (string sql : V9_SETUP_QUERIES) {
             SQLite::Statement(_db, sql).exec();
         }
+    }
+    if (version < 10) {
+        recomputeEventTimes();
     }
 
     // Update the version flag. Note that we don't want to go from v3 back to v2

--- a/MailSync/MailStore.hpp
+++ b/MailSync/MailStore.hpp
@@ -78,6 +78,9 @@ public:
 
     void migrate();
 
+    /** Rebuilds cached event start/end times from stored ICS. See the definition. */
+    void recomputeEventTimes();
+
     SQLite::Database & db();
 
     void resetForAccount(string accountId);

--- a/Vendor/icalendarlib/date.cpp
+++ b/Vendor/icalendarlib/date.cpp
@@ -23,12 +23,20 @@ Date &Date::operator =(const string &Text) {
 		if (Text.length() >= 15) {
 			sscanf(Text.c_str()+9, "%2hd%2hd%2hd", &Data[HOUR], &Data[MINUTE], &Data[SECOND]);
 			WithTime = true;
+			// A trailing "Z" makes the value UTC (RFC 5545 section 3.3.5); toUnix() needs it.
+			// Scan back over trailing whitespace: GetSubProperty() hands over RRULE parts such
+			// as UNTIL with the line's carriage return still attached, unlike GetProperty().
+			size_t last = Text.find_last_not_of(" \t\r\n");
+			IsUTC = (last != string::npos && (Text[last] == 'Z' || Text[last] == 'z'));
 		} else {
 			Data[HOUR] = Data[MINUTE] = Data[SECOND] = 0;
 			WithTime = false;
+			IsUTC = false;
 		}
-	} else
+	} else {
 		Data[YEAR] = Data[MONTH] = Data[DAY] = 0;
+		IsUTC = false;
+	}
 	return *this;
 }
 
@@ -128,6 +136,7 @@ void Date::SetToNow() {
 	Data[SECOND] = CurrentTime->tm_sec;
 	
 	WithTime = true;
+	IsUTC = false; // localtime() above gives a local wall-clock, not a UTC one
 }
 
 Date::DatePart &Date::DatePart::operator +=(short Value) {

--- a/Vendor/icalendarlib/date.h
+++ b/Vendor/icalendarlib/date.h
@@ -33,6 +33,14 @@ public:
 		Clear();
 	}
 	
+    /*
+     An iCalendar DATE-TIME is one of three things (RFC 5545 section 3.3.5): UTC when it ends
+     in "Z", a wall-clock time in a named zone when the property carries TZID, or floating.
+     Only UTC is unambiguous here, so only UTC uses timegm(); the other two resolve against
+     the local zone, which is correct for a floating time and for a TZID matching this
+     machine. tm_isdst is -1 so the C library determines daylight saving rather than assuming
+     standard time, which is an hour out for half the year.
+    */
     int toUnix() {
         struct tm timeinfo {};
         memset(&timeinfo, 0, sizeof(struct tm));
@@ -40,6 +48,14 @@ public:
         sprintf(Temp, "%.4d%.2d%.2dT%.2d%.2d%.2d", Data[YEAR], Data[MONTH], Data[DAY], Data[HOUR], Data[MINUTE], Data[SECOND]);
         std::istringstream ss(Temp);
         ss >> std::get_time(&timeinfo, "%Y%m%dT%H%M%S");
+        timeinfo.tm_isdst = -1; // let the C library work out DST for local times
+        if (IsUTC) {
+#ifdef _MSC_VER
+            return (int)_mkgmtime(&timeinfo);
+#else
+            return (int)timegm(&timeinfo);
+#endif
+        }
         return (int)mktime(&timeinfo);
     }
 
@@ -88,9 +104,12 @@ public:
 		
 		Data[HOUR] = Data[MINUTE] = Data[SECOND] = 0;
 		WithTime = false;
+		IsUTC = false;
 	}
 	
 	bool WithTime;
+	/** True when the value was written in UTC, i.e. ended in "Z". */
+	bool IsUTC;
 };
 
 class Date::DatePart {


### PR DESCRIPTION
icalendarlib's Date::toUnix() ran every DATE-TIME through mktime(), which
interprets the fields as local wall-clock time. A value ending in "Z" is UTC
(RFC 5545 section 3.3.5), so every UTC-stamped event landed on the calendar
shifted by the machine's UTC offset: five hours late in New York, an hour
early in Berlin. Google, Fastmail and iCloud all write DTSTART in UTC, so
this was nearly every synced event. The struct tm was also zeroed, so
tm_isdst was 0 and mktime() treated summer wall-clock times as standard
time - floating and TZID values were an hour off for half the year as well.

Date now records whether the value carried the "Z" suffix and converts UTC
through timegm() (_mkgmtime on MSVC, the same guard mailcore2 uses in
MCLibetpan.cpp). Local conversions set tm_isdst to -1 so the C library
resolves daylight saving. The suffix check skips trailing whitespace because
GetSubProperty() hands back RRULE parts such as UNTIL with the line's
carriage return still attached.

Cached event times are only computed when an event is fetched, and fetches
are gated on ctag and etag, so existing rows would otherwise keep the old
values indefinitely while new ones used the new convention. Schema version
10 recomputes recurrenceStart/recurrenceEnd and the rs/re fields from each
row's stored ICS, matching the row's own VEVENT by RECURRENCE-ID and UID so
an exception does not inherit its master's times. It runs in one
transaction and skips rows it cannot parse.

Verified:
- A harness compiling date.cpp alone, run under TZ=UTC, America/New_York,
  Europe/Berlin and Australia/Sydney: master is off by the UTC offset on
  every "Z" input and by an hour on summer floating times; this branch
  matches Python's own arithmetic on all 7 inputs in all 4 zones.
- Live sync against Radicale under TZ=America/New_York, master vs this
  branch: master stored a 13:00Z event at 18:00Z and a 09:00 New York
  event at 14:00Z; this branch stores both at 13:00Z.
- The migration on a copy of a real 322MB database with 875 events: 0.14s,
  version 9 -> 10, twenty deliberately corrupted rows restored to the
  values in their ICS, no other row changed.

One of the single-concern pieces of #123, which this supersedes in part.

Client side: the calendar's query window and the placement of a non-recurring event read `recurrenceStart`/`recurrenceEnd` straight from these rows (`calendar-data-source.ts`), so a UTC-stamped event the engine reads as local sits on the grid shifted by the machine's UTC offset whatever the client does with the ICS. Foundry376/Mailspring#2873 (merged 2026-09-17) has the client write DTSTAMP in UTC and Foundry376/Mailspring#2877 (open) read TZID values in their zone; this is the engine half of the same correction.

### CI

Runs from a fork wait for approval here, so these ran fork-internally on the same commit:

- Linux x64 and arm64: https://github.com/brhellman/Mailspring-Sync/actions/runs/34476324002
- Windows: https://github.com/brhellman/Mailspring-Sync/actions/runs/34476324084
- macOS (same content plus a fork-only workflow guard, since the fork has no signing certificate): 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
