### PR TITLE
Record whether each calendar is the account's own or shared into it

### DIFF
--- a/MailSync/DAVWorker.cpp
+++ b/MailSync/DAVWorker.cpp
@@ -719,6 +719,8 @@ string DAVWorker::resolveCalendarHomeURL() {
         calPrincipalURL = replacePath(calRoot, calPrincipalURL);
     }
 
+    cachedCalPrincipalPath = normalizeHref(calPrincipalURL);
+
     // PROPFIND principal → calendar-home-set (RFC 4791 §6.2.1)
     auto homeSetDoc = performXMLRequest(calPrincipalURL, "PROPFIND",
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
@@ -1371,6 +1373,51 @@ void DAVWorker::rebuildContactGroup(shared_ptr<Contact> contact) {
     group->syncMembers(store, members);
 }
 
+static string lowercased(string value) {
+    transform(value.begin(), value.end(), value.begin(), ::tolower);
+    return value;
+}
+
+/*
+ Whether this calendar belongs to the account we are syncing, rather than being one somebody
+ else has shared with it.
+
+ DAV:owner (RFC 3744 section 5.1) names the principal that owns the collection, which is the
+ server's own answer to the question. It matters because the client uses "is this calendar
+ mine" to pick which copy of an invitation to write an RSVP onto, and the alternative signal
+ - the calendar's display name - is text any sharer chooses. Someone who shares a writable
+ calendar named after the recipient's own address would otherwise capture their replies.
+
+ Returns "mine", "other", or "" when the server declines to say; an empty answer leaves the
+ client on its previous heuristic rather than asserting something unfounded.
+ */
+static string calendarOwnership(shared_ptr<DavXML> doc, xmlNodePtr responseNode,
+                                const string & principalPath) {
+    if (principalPath.empty()) {
+        return "";
+    }
+    const string ownerPath =
+        "./D:propstat[contains(./D:status, '200')]/D:prop/D:owner/D:href/text()";
+    string owner = doc->nodeContentAtXPath(ownerPath, responseNode);
+    if (owner.empty()) {
+        return "";
+    }
+
+    // Google's CalDAV principal resource is "<calendar-home>/user", so the owner href of an
+    // account's own calendar is the principal path with "/user" appended - the Gmail branch
+    // synthesises calPrincipal without it. On a server we discovered properly,
+    // cachedCalPrincipalPath is the real DAV:current-user-principal and matches outright.
+    // Case-folded on both sides: principalPath is built from the address as the user typed
+    // it when adding the account, while the server echoes back whatever case it stores, so
+    // an account added as "Alice@Gmail.com" would otherwise match nothing and every calendar
+    // on it would be marked as somebody else's - which silently disables scheduling with no
+    // failure to see. TaskProcessor compares attendee addresses the same way.
+    const string normalized = lowercased(normalizeHref(owner));
+    const string principal = lowercased(principalPath);
+    const bool mine = normalized == principal || normalized == principal + "/user";
+    return mine ? "mine" : "other";
+}
+
 void DAVWorker::runCalendars() {
     // Gmail uses calHost/calPrincipal set in constructor.
     // All other accounts use dynamic discovery (cached after first run).
@@ -1420,6 +1467,7 @@ void DAVWorker::runCalendars() {
         "<ical:calendar-color />"
         "<c:calendar-description />"
         "<d:current-user-privilege-set />"
+        "<d:owner />"
         "<ical:calendar-order />"
         "</d:prop>"
         "</d:propfind>";
@@ -1455,7 +1503,11 @@ void DAVWorker::runCalendars() {
         // Make a few xpath queries relative to the "D:response" calendar node (using "./")
         // to retrieve the attributes we're interested in.
         auto name = calendarSetDoc->nodeContentAtXPath(".//D:displayname/text()", node);
-        auto path = calendarSetDoc->nodeContentAtXPath(".//D:href/text()", node);
+        // The response's OWN href, as a direct child. Not ".//D:href": nodeContentAtXPath
+        // keeps the last node it visits, and DAV:owner carries a nested href, so a
+        // descendant search returns the owning principal's URL and every calendar ends up
+        // pointed at a principal instead of its own collection.
+        auto path = calendarSetDoc->nodeContentAtXPath("./D:href/text()", node);
         auto ctag = calendarSetDoc->nodeContentAtXPath(".//cs:getctag/text()", node);
         auto id = MailUtils::idForCalendar(account->id(), path);
 
@@ -1472,6 +1524,11 @@ void DAVWorker::runCalendars() {
             hasWritePrivilege = true;
         }), node);
         bool readOnly = !hasWritePrivilege;
+        // calPrincipal is the Gmail path's principal; cachedCalPrincipalPath the discovered
+        // one. Exactly one is ever set.
+        auto ownership = calendarOwnership(
+            calendarSetDoc, node,
+            calHost != "" ? normalizeHref(calPrincipal) : cachedCalPrincipalPath);
 
         shared_ptr<Calendar> calendar = local[id];
         bool needsSync = true;
@@ -1501,6 +1558,12 @@ void DAVWorker::runCalendars() {
                 calendar->setReadOnly(readOnly);
                 metadataChanged = true;
             }
+            // Only overwrite a known answer with another known answer: a server that stops
+            // returning DAV:owner shouldn't erase what it told us last time.
+            if (!ownership.empty() && calendar->ownership() != ownership) {
+                calendar->setOwnership(ownership);
+                metadataChanged = true;
+            }
             if (!orderStr.empty()) {
                 try {
                     int order = std::stoi(orderStr);
@@ -1525,6 +1588,7 @@ void DAVWorker::runCalendars() {
             }
             calendar->setDescription(description);
             calendar->setReadOnly(readOnly);
+            calendar->setOwnership(ownership);
             if (!orderStr.empty()) {
                 try {
                     calendar->setOrder(std::stoi(orderStr));

--- a/MailSync/DAVWorker.hpp
+++ b/MailSync/DAVWorker.hpp
@@ -48,6 +48,10 @@ class DAVWorker {
     // In-memory discovery cache for CalDAV
     bool calendarsDiscoveryComplete = false;
     string cachedCalendarHomeURL = "";
+    // The DAV:href of this account's own principal, retained from discovery so that
+    // runCalendars() can compare it against each calendar's DAV:owner. Empty when the
+    // server named no principal, which leaves ownership unknown rather than wrong.
+    string cachedCalPrincipalPath = "";
 
     bool validateCachedAddressBook();
 

--- a/MailSync/Models/Calendar.cpp
+++ b/MailSync/Models/Calendar.cpp
@@ -95,6 +95,14 @@ void Calendar::setReadOnly(bool readOnly) {
     _data["read_only"] = readOnly;
 }
 
+string Calendar::ownership() {
+    return _data.count("owner") ? _data["owner"].get<string>() : "";
+}
+
+void Calendar::setOwnership(string ownership) {
+    _data["owner"] = ownership;
+}
+
 int Calendar::order() {
     return _data.count("order") ? _data["order"].get<int>() : 0;
 }

--- a/MailSync/Models/Calendar.hpp
+++ b/MailSync/Models/Calendar.hpp
@@ -52,6 +52,11 @@ public:
     bool readOnly();
     void setReadOnly(bool readOnly);
 
+    // "mine" when DAV:owner named this account's own principal, "other" when it named
+    // somebody else's, and "" when the server didn't say. See calendarOwnership().
+    string ownership();
+    void setOwnership(string ownership);
+
     int order();
     void setOrder(int order);
 


### PR DESCRIPTION
The client has to decide which calendar an invitation reply is written onto,
and which calendars count as "mine" when checking for conflicts. Until now the
only signal was the calendar's display name, which is text whoever shared the
calendar chose: a colleague who shares a writable calendar named after the
recipient's own address would capture that person's RSVPs.

DAV:owner (RFC 3744 section 5.1) is the server's own answer. Discovery now
asks for it alongside the other calendar properties, resolves it against the
account's principal - DAV:current-user-principal on a discovered server, the
synthesised /caldav/v2/<address> principal on Gmail, where the owner href
carries Google's "/user" suffix - and stores "mine", "other" or "" on the
Calendar as `owner`. An empty answer means the server declined to say, and a
known answer is never overwritten by an empty one on a later pass. Comparison
is case-folded on both sides because the principal path is built from the
address as the user typed it and the server echoes whatever case it stores.

Asking for DAV:owner exposes a latent bug in how the calendar's own href was
read: ".//D:href" is a descendant search, nodeContentAtXPath keeps the last
node it visits, and DAV:owner carries a nested href - so every calendar came
back pointed at its owner's principal instead of its own collection. The
response's own href is now read as a direct child. Master never requests a
property that contains an href, which is why this did not bite before.

Verified against a scriptable CalDAV server, master vs this branch:

    DAV:owner on the calendar                   master   this branch
    the account's own principal                 (none)   mine
    somebody else's principal                   (none)   other
    property omitted                            (none)   ""
    absolute URL to the own principal           (none)   mine
    "/principals/alice@lab.test" vs a principal
      spelled "/principals/Alice%40lab.test/"   (none)   mine
    three calendars, one of each                (none)   mine / other / ""

Every calendar keeps its own path. The same branch built without the
own-href fix stores "/principals/alice/" as the path of a calendar at
"/calendars/alice/a/", which is the failure the fix exists for. Google's
"/user" suffix was exercised earlier against a live Workspace account, where
the user's own calendar resolves as mine and a shared resource calendar as
other.

One of the single-concern pieces of #123, which this supersedes in part.

### CI

Runs from a fork wait for approval here, so these ran fork-internally on the same commit:

- Linux x64 and arm64: https://github.com/brhellman/Mailspring-Sync/actions/runs/34476285481
- Windows: https://github.com/brhellman/Mailspring-Sync/actions/runs/34476285512
- macOS (same content plus a fork-only workflow guard, since the fork has no signing certificate): https://github.com/brhellman/Mailspring-Sync/actions/runs/34479242188

🤖 Generated with [Claude Code](https://claude.com/claude-code)