### PR TITLE
Accept an iTIP COUNTER in performRemoteSendRSVP alongside REPLY

### DIFF
--- a/MailSync/TaskProcessor.cpp
+++ b/MailSync/TaskProcessor.cpp
@@ -2162,13 +2162,23 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
         ? task->data()["icsRSVPStatus"].get<string>()
         : "ACCEPTED";
 
+    // The iTIP method being sent to the organizer. REPLY answers the invitation; COUNTER
+    // proposes a different time (RFC 5546 section 3.2.7). Absent means REPLY, so a client
+    // older than counter-proposal support keeps working unchanged.
+    string method = task->data().count("method")
+        ? task->data()["method"].get<string>()
+        : "REPLY";
+    if (method != "REPLY" && method != "COUNTER") {
+        throw SyncException("invalid-ics", "Unsupported iTIP method: " + method, false);
+    }
+
     // =========================================================================
     // RFC 5546/6047 Validation
     // =========================================================================
 
-    // Validation 1: Check ICS contains METHOD:REPLY (RFC 5546 requirement)
-    if (ics.find("METHOD:REPLY") == string::npos) {
-        throw SyncException("invalid-ics", "ICS data must contain METHOD:REPLY for an RSVP response", false);
+    // Validation 1: the ICS must declare the method we're sending it as (RFC 5546)
+    if (ics.find("METHOD:" + method) == string::npos) {
+        throw SyncException("invalid-ics", "ICS data must contain METHOD:" + method, false);
     }
 
     // Parse the ICS to validate and extract event information
@@ -2183,34 +2193,46 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
     // Validation 2: UID is required (RFC 5546 Section 3.2.3 - MUST match original REQUEST)
     if (event->UID.empty()) {
         throw SyncException("invalid-ics",
-            "ICS REPLY must contain UID property matching the original invitation", false);
+            "ICS " + method + " must contain UID property matching the original invitation", false);
     }
 
     // Validation 3: DTSTAMP is required (RFC 5546 Section 3.2.3)
     if (event->DtStamp.IsEmpty()) {
         throw SyncException("invalid-ics",
-            "ICS REPLY must contain DTSTAMP property", false);
+            "ICS " + method + " must contain DTSTAMP property", false);
     }
 
     // Validation 4: ORGANIZER is required (RFC 5546 Section 3.2.3)
     if (event->Organizer.empty()) {
         throw SyncException("invalid-ics",
-            "ICS REPLY must contain ORGANIZER property", false);
+            "ICS " + method + " must contain ORGANIZER property", false);
     }
 
-    // Validation 5: REPLY must contain exactly one ATTENDEE (RFC 5546 Section 3.2.3)
-    if (event->Attendees.size() != 1) {
+    // Validation 5: a REPLY carries exactly one ATTENDEE, the person replying (RFC 5546
+    // Section 3.2.3). A COUNTER carries the proposing attendee and may repeat the rest of
+    // the guest list, so it only needs at least one (Section 3.2.7).
+    if (method == "REPLY" && event->Attendees.size() != 1) {
         throw SyncException("invalid-ics",
             "ICS REPLY must contain exactly one ATTENDEE (the replying user), found " + to_string(event->Attendees.size()), false);
     }
-
-    // Validation 6: Check ATTENDEE has valid PARTSTAT (RFC 5545 Section 3.2.12)
-    bool hasValidPartstat = (ics.find("PARTSTAT=ACCEPTED") != string::npos ||
-                             ics.find("PARTSTAT=DECLINED") != string::npos ||
-                             ics.find("PARTSTAT=TENTATIVE") != string::npos);
-    if (!hasValidPartstat) {
+    if (method == "COUNTER" && event->Attendees.empty()) {
         throw SyncException("invalid-ics",
-            "ATTENDEE must have valid PARTSTAT parameter (ACCEPTED, DECLINED, or TENTATIVE)", false);
+            "ICS COUNTER must contain the ATTENDEE making the proposal", false);
+    }
+
+    // Validation 6: a REPLY states a participation status (RFC 5545 Section 3.2.12); a
+    // COUNTER states a time instead, so it needs DTSTART rather than a PARTSTAT.
+    if (method == "REPLY") {
+        bool hasValidPartstat = (ics.find("PARTSTAT=ACCEPTED") != string::npos ||
+                                 ics.find("PARTSTAT=DECLINED") != string::npos ||
+                                 ics.find("PARTSTAT=TENTATIVE") != string::npos);
+        if (!hasValidPartstat) {
+            throw SyncException("invalid-ics",
+                "ATTENDEE must have valid PARTSTAT parameter (ACCEPTED, DECLINED, or TENTATIVE)", false);
+        }
+    } else if (event->DtStart.IsEmpty()) {
+        throw SyncException("invalid-ics",
+            "ICS COUNTER must contain the proposed DTSTART", false);
     }
 
     // Extract attendee email for From address validation
@@ -2248,7 +2270,15 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
 
     // Generate human-readable text based on RSVP status (per RFC 6047 recommendation)
     string humanReadableText;
-    if (icsRSVPStatus == "ACCEPTED") {
+    if (method == "COUNTER") {
+        humanReadableText = fromEmail + " proposed a new time for: " + eventSummary;
+        if (task->data().count("comment")) {
+            string comment = task->data()["comment"].get<string>();
+            if (!comment.empty()) {
+                humanReadableText += "\r\n\r\n" + comment;
+            }
+        }
+    } else if (icsRSVPStatus == "ACCEPTED") {
         humanReadableText = fromEmail + " has accepted the invitation to: " + eventSummary;
     } else if (icsRSVPStatus == "DECLINED") {
         humanReadableText = fromEmail + " has declined the invitation to: " + eventSummary;
@@ -2259,7 +2289,7 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
     }
 
     // Generate a unique boundary for multipart message
-    string boundary = "----=_Mailspring_RSVP_" + to_string(time(0)) + "_" + to_string(rand());
+    string boundary = "----=_Mailspring_" + method + "_" + to_string(time(0)) + "_" + to_string(rand());
 
     // Base64 encode the ICS data (RFC 6047 recommends base64 for maximum compatibility)
     Data * icsData = AS_MCSTR(ics)->dataUsingEncoding("utf-8");
@@ -2289,8 +2319,9 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
     mimeBody << humanReadableText << "\r\n";
     mimeBody << "\r\n";
     mimeBody << "--" << boundary << "\r\n";
-    // Critical: Content-Type MUST include method=REPLY parameter (RFC 6047 Section 2.4)
-    mimeBody << "Content-Type: text/calendar; method=REPLY; charset=UTF-8\r\n";
+    // Critical: Content-Type MUST include the method parameter (RFC 6047 Section 2.4), and
+    // it MUST agree with the METHOD inside the ICS or receiving calendars discard it.
+    mimeBody << "Content-Type: text/calendar; method=" << method << "; charset=UTF-8\r\n";
     mimeBody << "Content-Transfer-Encoding: base64\r\n";
     // Use inline disposition, not attachment (RFC 6047 Section 2.4)
     mimeBody << "Content-Disposition: inline; filename=\"invite.ics\"\r\n";
@@ -2351,7 +2382,7 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
     SMTPProgress sprogress;
     MailUtils::configureSessionForAccount(smtp, account);
 
-    logger->info("-- Sending RFC 6047-compliant RSVP ({}) to organizer {}", icsRSVPStatus, organizer);
+    logger->info("-- Sending RFC 6047-compliant {} ({}) to organizer {}", method, icsRSVPStatus, organizer);
     smtp.sendMessage(messageData, &sprogress, &err);
 
     if (err != ErrorNone) {
@@ -2361,5 +2392,5 @@ void TaskProcessor::performRemoteSendRSVP(Task * task) {
         throw SyncException("send-failed", ErrorCodeToTypeMap[err], false);
     }
 
-    logger->info("-- RSVP sent successfully");
+    logger->info("-- {} sent successfully", method);
 }


### PR DESCRIPTION
An attendee who cannot make the proposed time sends a COUNTER (RFC 5546
section 3.2.7) - Google Calendar's "Propose a new time". The engine rejected
anything that was not a REPLY: the ICS had to contain METHOD:REPLY, exactly
one ATTENDEE, and a PARTSTAT.

The task may now carry "method": "REPLY" or "COUNTER"; absent means REPLY, so
a client without counter-proposal support keeps working unchanged. Validation
follows the method: a COUNTER must carry the proposing attendee and may repeat
the rest of the guest list (at least one ATTENDEE rather than exactly one),
and states a time rather than a participation status, so it needs DTSTART
rather than PARTSTAT. The Content-Type method parameter (RFC 6047 section
2.4) and the METHOD inside the ICS are both set from the same value, since
receiving calendars discard a message where they disagree. The human-readable
part says a new time was proposed and appends the user's note from the task's
"comment" field. Anything other than REPLY or COUNTER is refused.

The client half - building the COUNTER from the original event and offering
the action in the invitation header - is in Foundry376/Mailspring and depends
on this landing first.

Verified against a local SMTP/IMAP server, queueing an EventRSVPTask with
method COUNTER and a 13-attendee ICS through the engine's stdin:

    master:  task fails "ICS data must contain METHOD:REPLY for an RSVP
             response"; nothing sent
    branch:  message delivered; Content-Type: text/calendar; method=COUNTER;
             METHOD:COUNTER and the proposed DTSTART in the decoded part;
             all 13 attendees present; the comment in the text part

A REPLY sent through the same branch is unchanged from master.

One of the single-concern pieces of #123, which this supersedes in part.

### CI

Runs from a fork wait for approval here, so these ran fork-internally on the same commit:

- Linux x64 and arm64: https://github.com/brhellman/Mailspring-Sync/actions/runs/34476307840
- Windows: https://github.com/brhellman/Mailspring-Sync/actions/runs/34476307753
- macOS (same content plus a fork-only workflow guard, since the fork has no signing certificate): https://github.com/brhellman/Mailspring-Sync/actions/runs/34479275669

🤖 Generated with [Claude Code](https://claude.com/claude-code)