### PR TITLE
Poll calendars every 15 minutes and contacts every fifth pass

### DIFF
--- a/MailSync/main.cpp
+++ b/MailSync/main.cpp
@@ -232,16 +232,29 @@ void runCalContactsSyncWorker() {
     std::this_thread::sleep_for(std::chrono::seconds(15 + davWorker->account->startDelay()));
 
     // BG Note: This process does not use MailUtils::sleepWorkerUntilWakeOrSec(), which means
-    // cal + contact sync runs every 15 minutes regardless of how often you slam on the Sync Mail
-    // icon. I am trying to narrow down why we are hitting the Google Calendar + People API limits
-    // so quickly (in almost exactly 8 hours after the 2AM reset each day).
+    // cal + contact sync runs on a fixed cadence regardless of how often you slam on the Sync
+    // Mail icon. I am trying to narrow down why we are hitting the Google Calendar + People API
+    // limits so quickly (in almost exactly 8 hours after the 2AM reset each day).
 
-    while(true) {
+    // Calendars poll more often than contacts: an unchanged calendar usually costs one
+    // PROPFIND because runCalendars() compares ctags before fetching anything, while contact
+    // sync has no such early-out and on Gmail spends the People API quota the note above
+    // concerns. Servers that omit ctag re-list every calendar per pass, which is why this is
+    // minutes rather than seconds; editing an event refreshes on demand regardless.
+    const auto calendarInterval = std::chrono::minutes(15);
+    const int calendarCyclesPerContactSync = 5; // contacts every 5th calendar pass
+
+    for (int cycle = 0; ; cycle++) {
         try {
-            if (contactsWorker) {
+            bool syncContacts = (cycle % calendarCyclesPerContactSync == 0);
+            if (contactsWorker && syncContacts) {
                 contactsWorker->run();
             }
-            davWorker->run();
+            if (syncContacts) {
+                davWorker->run();
+            } else {
+                davWorker->runCalendars();
+            }
         } catch (SyncException & ex) {
             exceptions::logCurrentExceptionWithStackTrace();
 
@@ -273,7 +286,7 @@ void runCalContactsSyncWorker() {
             return;
             // abort();
         }
-        std::this_thread::sleep_for(std::chrono::minutes(45));
+        std::this_thread::sleep_for(calendarInterval);
     }
 }
 


### PR DESCRIPTION
runCalContactsSyncWorker() ran contacts and calendars together every 45
minutes. Calendar changes made elsewhere - an invitation accepted on a phone,
a meeting moved by the organizer - took up to three quarters of an hour to
appear, while the interval was sized for the expensive half of the pair: on
Gmail, contact sync spends People API quota and has no early-out.

An unchanged calendar costs one PROPFIND per pass, because runCalendars()
compares ctags before fetching anything, so calendars can afford to poll
every 15 minutes. Contacts keep their old cadence by running on every fifth
calendar pass, 75 minutes rather than 45, which is fewer People API calls per
day than before, not more. Servers that omit ctag re-list every calendar per
pass, which is why the interval is minutes rather than seconds; editing an
event still refreshes on demand.

This is a policy change rather than a bug fix, so it is its own change to
accept or decline on its own terms. Built and run against a local CalDAV
server; the first pass syncs both, as before. The interval itself is not
observable in a short run and is asserted from the code.

One of the single-concern pieces of #123, which this supersedes in part.

### CI

Runs from a fork wait for approval here, so these ran fork-internally on the same commit:

- Linux x64 and arm64: https://github.com/brhellman/Mailspring-Sync/actions/runs/34476294567
- Windows: https://github.com/brhellman/Mailspring-Sync/actions/runs/34476294511
- macOS (same content plus a fork-only workflow guard, since the fork has no signing certificate): https://github.com/brhellman/Mailspring-Sync/actions/runs/34479258747

🤖 Generated with [Claude Code](https://claude.com/claude-code)